### PR TITLE
Autobuilder improvements

### DIFF
--- a/AutoBuilder/AutoBuilder.cs
+++ b/AutoBuilder/AutoBuilder.cs
@@ -69,17 +69,39 @@ namespace AutoBuilder
 
         public Dictionary<string, bool> Types = typeWeightings;
 
-        private static Dictionary<string, bool> MakeDefaultTypeWeightings()
+        public AutoBuilderWeightings() : this(MakeDefaultTypeWeightings())
         {
-            Dictionary<string, bool> typeWeightings = [];
-            foreach (string type in Globals.AllTypes)
-            {
-                typeWeightings[type] = true;
-            }
-            return typeWeightings;
         }
 
-        public AutoBuilderWeightings() : this(MakeDefaultTypeWeightings())
+        // copy constructor
+        public AutoBuilderWeightings(AutoBuilderWeightings clone) : this(
+            clone.Types
+            , resistanceAll: clone.ResistanceAll
+            , resistanceBalance: clone.ResistanceBalance
+            , resistanceAmount: clone.ResistanceAmount
+
+            , weaknessBalance: clone.WeaknessBalance
+            , weaknessAmount: clone.WeaknessAmount
+
+            , stabAll: clone.StabAll
+            , stabBalance: clone.StabBalance
+            , stabAmount: clone.StabAmount
+            
+            , moveSetAll: clone.MoveSetAll
+            , moveSetBalance: clone.MoveSetBalance
+            , moveSetAmount: clone.MoveSetAmount
+
+            , coverageOnOffensive: clone.CoverageOnOffensive
+            , resistancesOnDefensive: clone.ResistancesOnDefensive
+
+            , baseStatTotal: clone.BaseStatTotal
+            , baseStatHp: clone.BaseStatHp
+            , baseStatAtt: clone.BaseStatAtt
+            , baseStatDef: clone.BaseStatDef
+            , baseStatSpAtt: clone.BaseStatSpAtt
+            , baseStatSpDef: clone.BaseStatSpDef
+            , baseStatSpe: clone.BaseStatSpe
+        )
         {
         }
 
@@ -113,6 +135,16 @@ namespace AutoBuilder
             sum += BaseStatSpe;
 
             return sum;
+        }
+
+                public static Dictionary<string, bool> MakeDefaultTypeWeightings()
+        {
+            Dictionary<string, bool> typeWeightings = [];
+            foreach (string type in Globals.AllTypes)
+            {
+                typeWeightings[type] = true;
+            }
+            return typeWeightings;
         }
     }
 

--- a/AutoBuilder/AutoBuilder.cs
+++ b/AutoBuilder/AutoBuilder.cs
@@ -88,14 +88,22 @@ namespace AutoBuilder
             double sum = 0;
 
             sum += ResistanceAll;
+            sum += ResistanceBalance;
+            sum += ResistanceAmount;
+
+            sum += WeaknessBalance;
+            sum += WeaknessAmount;
+
             sum += StabAll;
+            sum += StabBalance;
+            sum += StabAmount;
+
+            sum += MoveSetAll;
+            sum += MoveSetBalance;
+            sum += MoveSetAmount;
+
             sum += CoverageOnOffensive;
             sum += ResistancesOnDefensive;
-
-            sum += MoveSetBalance;
-            sum += StabBalance;
-            sum += ResistanceBalance;
-            sum += WeaknessBalance;
 
             sum += BaseStatHp;
             sum += BaseStatAtt;

--- a/AutoBuilder/AutoBuilder.cs
+++ b/AutoBuilder/AutoBuilder.cs
@@ -5,29 +5,69 @@ using Utility;
 
 namespace AutoBuilder
 {
-    public class AutoBuilderWeightings
+    // contains doubles that represent the importance of each parameter for team generation
+    // all doubles are between 0 and 1.0
+    public class AutoBuilderWeightings(
+            Dictionary<string, bool> typeWeightings
+            , double resistanceAll = 1.0
+            , double resistanceBalance = 1.0
+            , double resistanceAmount = 1.0
+
+            , double weaknessAmount = 1.0
+            , double weaknessBalance = 1.0
+
+            , double stabAll = 1.0
+            , double stabBalance = 1.0
+            , double stabAmount = 1.0
+
+            , double moveSetAll = 1.0
+            , double moveSetBalance = 1.0
+            , double moveSetAmount = 1.0
+
+            , double coverageOnOffensive = 1.0
+            , double resistancesOnDefensive = 1.0
+
+            , double baseStatTotal = 1.0
+            , double baseStatHp = 0.5
+            , double baseStatAtt = 0.5
+            , double baseStatDef = 0.5
+            , double baseStatSpAtt = 0.5
+            , double baseStatSpDef = 0.5
+            , double baseStatSpe = 0.5)
     {
-        // priorities                               Weighting values
-        public double ResistantAll;                 // max 1.0
-        public double STABCoverageAll;              // max 1.0
-		public double CoverageOnOffensive;          // max 1.0
-		public double ResistancesOnDefensive;       // max 1.0
+        // resistances
+        public double ResistanceAll = resistanceAll;
+		public double ResistanceBalance = resistanceBalance;
+        public double ResistanceAmount = resistanceAmount;
 
-		// balance weightings
-		public double MoveSetBalance;      // max 1.0
-        public double StabBalance;         // max 1.0
-		public double ResistanceBalance;   // max 1.0
-		public double WeaknessBalance;     // max 1.0
+        // weaknesses
+        public double WeaknessAmount = weaknessAmount;
+		public double WeaknessBalance = weaknessBalance;
 
-		public double BaseStatTotal;       // max 1.0 scales other stat weightings
-		public double BaseStatHp;          // max 1.0
-		public double BaseStatAtt;         // max 1.0
-		public double BaseStatDef;         // max 1.0
-		public double BaseStatSpAtt;       // max 1.0
-		public double BaseStatSpDef;       // max 1.0
-		public double BaseStatSpe;         // max 1.0
+        // STAB
+        public double StabAll = stabAll;
+        public double StabBalance = stabBalance;
+        public double StabAmount = stabAmount;
 
-        public Dictionary<string, bool> Types = [];
+        // Moves
+        public double MoveSetAll = moveSetAll;
+		public double MoveSetBalance = moveSetBalance;
+        public double MoveSetAmount = moveSetAmount;
+
+        // misc weightings
+		public double CoverageOnOffensive = coverageOnOffensive;
+		public double ResistancesOnDefensive = resistancesOnDefensive;
+
+        // base stats
+		public double BaseStatTotal = baseStatTotal; // scales other stat weightings
+		public double BaseStatHp = baseStatHp;
+		public double BaseStatAtt = baseStatAtt;
+		public double BaseStatDef = baseStatDef;
+		public double BaseStatSpAtt = baseStatSpAtt;
+		public double BaseStatSpDef = baseStatSpDef;
+		public double BaseStatSpe = baseStatSpe;
+
+        public Dictionary<string, bool> Types = typeWeightings;
 
         private static Dictionary<string, bool> MakeDefaultTypeWeightings()
         {
@@ -39,46 +79,6 @@ namespace AutoBuilder
             return typeWeightings;
         }
 
-		public AutoBuilderWeightings(
-            Dictionary<string, bool> typeWeightings
-            , double resistantAll = 1.0
-            , double stabCoverageAll = 1.0
-            , double coverageOnOffensive = 1.0
-            , double resistancesOnDefensive = 1.0
-
-            , double moveSetBalanceWeighting = 1.0
-            , double stabBalanceWeighting = 1.0
-            , double resistanceBalanceWeighting = 1.0
-            , double weaknessBalanceWeighting = 1.0
-
-            , double baseStatTotalWeighting = 1.0
-            , double baseStatHpWeighting = 0.5
-            , double baseStatAttWeighting = 0.5
-            , double baseStatDefWeighting = 0.5
-            , double baseStatSpAttWeighting = 0.5
-            , double baseStatSpDefWeighting = 0.5
-            , double baseStatSpeWeighting = 0.5)
-        {
-            ResistantAll = resistantAll;
-            STABCoverageAll = stabCoverageAll;
-            CoverageOnOffensive = coverageOnOffensive;
-            ResistancesOnDefensive = resistancesOnDefensive;
-
-            MoveSetBalance = moveSetBalanceWeighting;
-            StabBalance = stabBalanceWeighting;
-            ResistanceBalance = resistanceBalanceWeighting;
-            WeaknessBalance = weaknessBalanceWeighting;
-
-            BaseStatTotal = baseStatTotalWeighting;
-            BaseStatHp = baseStatHpWeighting;
-            BaseStatAtt = baseStatAttWeighting;
-            BaseStatDef = baseStatDefWeighting;
-            BaseStatSpAtt = baseStatSpAttWeighting;
-            BaseStatSpDef = baseStatSpDefWeighting;
-            BaseStatSpe = baseStatSpeWeighting;
-
-            Types = typeWeightings;
-        }
         public AutoBuilderWeightings() : this(MakeDefaultTypeWeightings())
         {
         }
@@ -87,8 +87,8 @@ namespace AutoBuilder
         {
             double sum = 0;
 
-            sum += ResistantAll;
-            sum += STABCoverageAll;
+            sum += ResistanceAll;
+            sum += StabAll;
             sum += CoverageOnOffensive;
             sum += ResistancesOnDefensive;
 
@@ -116,21 +116,31 @@ namespace AutoBuilder
             // use another list of weightings to get the individual score from each parameter
             AutoBuilderWeightings result = new(                
                 weightings.Types
-                , resistantAll: 0.0
-                , stabCoverageAll: 0.0
+                , resistanceAll: 0.0
+                , resistanceBalance: 0.0
+                , resistanceAmount: 0.0
+
+                , weaknessBalance: 0.0
+                , weaknessAmount: 0.0
+
+                , stabAll: 0.0
+                , stabBalance: 0.0
+                , stabAmount: 0.0
+
+                , moveSetAll: 0.0
+                , moveSetBalance: 0.0
+                , moveSetAmount: 0.0
+
                 , coverageOnOffensive: 0.0
                 , resistancesOnDefensive: 0.0
-                , moveSetBalanceWeighting: 0.0
-                , stabBalanceWeighting: 0.0
-                , resistanceBalanceWeighting: 0.0
-                , weaknessBalanceWeighting: 0.0
-                , baseStatTotalWeighting: 0.0
-                , baseStatHpWeighting: 0.0
-                , baseStatAttWeighting: 0.0
-                , baseStatDefWeighting: 0.0
-                , baseStatSpAttWeighting: 0.0
-                , baseStatSpDefWeighting: 0.0
-                , baseStatSpeWeighting: 0.0
+
+                , baseStatTotal: 0.0
+                , baseStatHp: 0.0
+                , baseStatAtt: 0.0
+                , baseStatDef: 0.0
+                , baseStatSpAtt: 0.0
+                , baseStatSpDef: 0.0
+                , baseStatSpe: 0.0
             );
 
             if (team.CountPokemon() == 0)
@@ -165,56 +175,34 @@ namespace AutoBuilder
 
             // --- calculate the scores ---
 
-            // STAB coverage score
-            if (weightings.STABCoverageAll > 0
+            // - Resistance scores -
+            // Resistant to all types
+            if (weightings.ResistanceAll > 0
                 && totalTypes > 0)
             {
-                result.STABCoverageAll = weightings.STABCoverageAll;
-                double scorePerType = result.STABCoverageAll / totalTypes;
-                foreach (string type in Globals.AllTypes)
-                {
-                    if (weightings.Types[type] // only reduce if the type is being counted
-                        && STABcoverage.TryGetValue(type, out int count) && count < 1)
-                    {
-                        result.STABCoverageAll -= scorePerType;
-                    }
-                }
-            }
-
-            // Resistant All score
-            if (weightings.ResistantAll > 0
-                && totalTypes > 0)
-            {
-                result.ResistantAll = weightings.ResistantAll;
-                double scorePerType = result.ResistantAll / totalTypes;
+                result.ResistanceAll = weightings.ResistanceAll;
+                double scorePerType = result.ResistanceAll / totalTypes;
                 foreach (string type in Globals.AllTypes)
                 {
                     if (weightings.Types[type] // only reduce if the type is being counted
                         && resistances.TryGetValue(type, out int count) && count < 1)
                     {
-                        result.ResistantAll -= scorePerType;
+                        result.ResistanceAll -= scorePerType;
                     }
                 }
             }
-
-            // offensive pokemon have good coverage score
-            if (weightings.CoverageOnOffensive > 0)
-            {
-                result.CoverageOnOffensive = CalculateCoverageScore(team, weightings) * weightings.CoverageOnOffensive;
-            }
-
-            // defensive pokemon have good resistances score
-            if (weightings.ResistancesOnDefensive > 0)
-            {
-                result.ResistancesOnDefensive = CalculateResistancesScore(team, weightings) * weightings.ResistancesOnDefensive;
-            }
-
             // resistance balance score
             if (weightings.ResistanceBalance > 0
                 && totalTypes > 0)
             {
-                // create a score 0.0 - 1.0 based on how many resistances the team has
-                // vs the types we're interested in
+                double resistancesSD = CalculateStandardDeviation(resistances, weightings);
+                result.ResistanceBalance = 1.0 - (0.2 * resistancesSD);
+                result.ResistanceBalance *= weightings.ResistanceBalance;
+            }
+            // resistance amount score
+            if (weightings.ResistanceAmount > 0
+                && totalTypes > 0)
+            {
                 int totalInterestedResistances = 0;
                 foreach (string type in Globals.AllTypes)
                 {
@@ -223,19 +211,25 @@ namespace AutoBuilder
                         totalInterestedResistances += resistances[type];
                     }
                 }
-                result.ResistanceBalance = 1.0 - Math.Pow((2 * totalTypes - 1) / (2 * totalTypes), totalInterestedResistances);
-
-                double resistancesSD = CalculateStandardDeviation(resistances, weightings);
-                result.ResistanceBalance = Math.Pow(result.ResistanceBalance, 1.0 + resistancesSD);
-                result.ResistanceBalance *= weightings.ResistanceBalance;
+                // use a semi-logarithmic algorithm to make increasing resistances scale closer to (but never reach) 1.0
+                result.ResistanceAmount = 1.0 - Math.Pow((2 * totalTypes - 1) / (2 * totalTypes), 2 * totalInterestedResistances);
+                result.ResistanceAmount *= weightings.ResistanceAmount;
             }
 
+
+            // - Weaknesses scores -
             // weaknesses balance score
             if (weightings.WeaknessBalance > 0
                 && totalTypes > 0)
             {
-                // create a score 0.0 - 1.0 based on how many weaknesses the team has
-                // vs the types we're interested in
+                double weaknessesSD = CalculateStandardDeviation(weaknesses, weightings);
+                result.WeaknessBalance = 1.0 - (0.2 * weaknessesSD);
+                result.WeaknessBalance *= weightings.WeaknessBalance;
+            }
+            // weaknesses amount score
+            if (weightings.WeaknessAmount > 0
+                && totalTypes > 0)
+            {
                 int totalInterestedWeaknesses = 0;
                 foreach (string type in Globals.AllTypes)
                 {
@@ -244,56 +238,107 @@ namespace AutoBuilder
                         totalInterestedWeaknesses += weaknesses[type];
                     }
                 }
-                result.WeaknessBalance = 1.0 - Math.Pow((2 * totalTypes - 1) / (2 * totalTypes), totalInterestedWeaknesses);
-
-                double weaknessesSD = CalculateStandardDeviation(weaknesses, weightings);
-                result.WeaknessBalance = Math.Pow(result.WeaknessBalance, 1.0 + weaknessesSD);
-                result.WeaknessBalance *= weightings.WeaknessBalance;
+                // use a semi-logarithmic algorithm to make increasing weakness scale closer to (but never reach) 0
+                result.WeaknessAmount = Math.Pow((2 * totalTypes - 1) / (2 * totalTypes), 2 * totalInterestedWeaknesses);
+                result.WeaknessAmount *= weightings.WeaknessAmount;
             }
 
-            // move coverage balance score
-            if (weightings.MoveSetBalance > 0
+
+            // - STAB scores -
+            // STAB coverage againt all types
+            if (weightings.StabAll > 0
                 && totalTypes > 0)
             {
-                // create a score 0.0 - 1.0 based on how good the move coverage is
-                // vs the types we're interested in
-                int totalInterestedMoveCoverage = 0;
+                result.StabAll = weightings.StabAll;
+                double scorePerType = result.StabAll / totalTypes;
                 foreach (string type in Globals.AllTypes)
                 {
-                    if (weightings.Types[type])
+                    if (weightings.Types[type] // only reduce if the type is being counted
+                        && STABcoverage.TryGetValue(type, out int count) && count < 1)
                     {
-                        totalInterestedMoveCoverage += movecoverage[type];
+                        result.StabAll -= scorePerType;
                     }
                 }
-                result.MoveSetBalance = 1.0 - Math.Pow((2 * totalTypes - 1) / (2 * totalTypes), totalInterestedMoveCoverage);
-
-                double moveBalanceSD = CalculateStandardDeviation(movecoverage, weightings);
-                result.MoveSetBalance = Math.Pow(result.MoveSetBalance, 1.0 + moveBalanceSD);
-                result.MoveSetBalance *= weightings.MoveSetBalance;
             }
-
             // STAB coverage balance score
             if (weightings.StabBalance > 0
                 && totalTypes > 0)
             {
-                // create a score 0.0 - 1.0 based on how good the STAB coverage is
-                // vs the types we're interested in
-                int totalInterestedSTABCoverage = 0;
+                double stabBalanceSD = CalculateStandardDeviation(STABcoverage, weightings);
+                result.StabBalance = 1.0 - (0.2 * stabBalanceSD);
+                result.StabBalance *= weightings.StabBalance;
+            }
+            // STAB coverage amount
+            if (weightings.StabAmount > 0
+                && totalTypes > 0)
+            {
+                int totalInterestedStabCoverage = 0;
                 foreach (string type in Globals.AllTypes)
                 {
                     if (weightings.Types[type])
                     {
-                        totalInterestedSTABCoverage += STABcoverage[type];
+                        totalInterestedStabCoverage += STABcoverage[type];
                     }
                 }
-                result.StabBalance = 1.0 - Math.Pow((2 * totalTypes - 1) / (2 * totalTypes), totalInterestedSTABCoverage);
-
-                double stabBalanceSD = CalculateStandardDeviation(STABcoverage, weightings);
-                result.StabBalance = Math.Pow(result.StabBalance, 1.0 + stabBalanceSD);
-                result.StabBalance *= weightings.StabBalance;
+                // use a semi-logarithmic algorithm to make increasing STAB coverage scale closer to (but never reach) 1.0
+                result.StabAmount = 1.0 - Math.Pow((2 * totalTypes - 1) / (2 * totalTypes), 2 * totalInterestedStabCoverage);
+                result.StabAmount *= weightings.StabAmount;
             }
 
-            // base stat scores
+            // - Move set scores -
+            // Move set coverage againt all types
+            if (weightings.MoveSetAll > 0
+                && totalTypes > 0)
+            {
+                result.MoveSetAll = weightings.MoveSetAll;
+                double scorePerType = result.MoveSetAll / totalTypes;
+                foreach (string type in Globals.AllTypes)
+                {
+                    if (weightings.Types[type] // only reduce if the type is being counted
+                        && movecoverage.TryGetValue(type, out int count) && count < 1)
+                    {
+                        result.MoveSetAll -= scorePerType;
+                    }
+                }
+            }
+            // move coverage balance score
+            if (weightings.MoveSetBalance > 0
+                && totalTypes > 0)
+            {
+                double moveBalanceSD = CalculateStandardDeviation(movecoverage, weightings);
+                result.MoveSetBalance = 1.0 - (0.2 * moveBalanceSD);
+                result.MoveSetBalance *= weightings.MoveSetBalance;
+            }
+            // move set coverage amount
+            if (weightings.MoveSetAmount > 0
+                && totalTypes > 0)
+            {
+                int totalInterestedMoveSetCoverage = 0;
+                foreach (string type in Globals.AllTypes)
+                {
+                    if (weightings.Types[type])
+                    {
+                        totalInterestedMoveSetCoverage += movecoverage[type];
+                    }
+                }
+                // use a semi-logarithmic algorithm to make increasing STAB coverage scale closer to (but never reach) 1.0
+                result.MoveSetAmount = 1.0 - Math.Pow((2 * totalTypes - 1) / (2 * totalTypes), 2 * totalInterestedMoveSetCoverage);
+                result.MoveSetAmount *= weightings.MoveSetAmount;
+            }
+
+            // - Misc Scores -
+            // offensive pokemon have good coverage score
+            if (weightings.CoverageOnOffensive > 0)
+            {
+                result.CoverageOnOffensive = CalculateCoverageScore(team, weightings) * weightings.CoverageOnOffensive;
+            }
+            // defensive pokemon have good resistances score
+            if (weightings.ResistancesOnDefensive > 0)
+            {
+                result.ResistancesOnDefensive = CalculateResistancesScore(team, weightings) * weightings.ResistancesOnDefensive;
+            }
+
+            // - Base stat scores - 
             if (weightings.BaseStatTotal > 0)
             {
                 CalculateStatsScore(team, weightings, result);

--- a/PokeAutobuilder/Shared/AutoBuilderDialog.razor
+++ b/PokeAutobuilder/Shared/AutoBuilderDialog.razor
@@ -144,8 +144,7 @@
                 <MudItem xs="12" md="6" lg="4">
                     <MudText Typo="Typo.h6">Weaknesses</MudText>
                     <MudText Typo="Typo.subtitle1">Use the sliders to fine-tune the importance of type weaknesses.</MudText>
-                    <MudStack Class="px-2 pt-8">
-
+                    <MudStack Class="px-2">
                         <WeightingSlider Name="Balance"
                                          Tooltip="Importance of a balanced number of type weaknesses."
                                          @bind-Value="weaknessBalance"

--- a/PokeAutobuilder/Shared/AutoBuilderDialog.razor
+++ b/PokeAutobuilder/Shared/AutoBuilderDialog.razor
@@ -196,18 +196,18 @@
 
     public Dictionary<string, bool> typeWeightings = [];
 
-    public double resistantAll = 1.0;
-    public double stabCoverageAll = 1.0;
-    public double coverageOnOffensive = 1.0;
-    public double resistancesOnDefensive = 0.5;
+    public double resistantAll = 0.5;
+    public double stabCoverageAll = 0.5;
+    public double coverageOnOffensive = 0.0;
+    public double resistancesOnDefensive = 0.0;
 
-    public double moveSetBalanceWeighting = 0.0;
-    public double stabBalanceWeighting = 1.0;
-    public double resistanceBalanceWeighting = 1.0;
+    public double moveSetBalanceWeighting = 0.5;
+    public double stabBalanceWeighting = 0.5;
+    public double resistanceBalanceWeighting = 0.5;
     public double weaknessBalanceWeighting = 0.5;
 
     // base stats
-    public double baseStatTotalWeighting = 1.0;
+    public double baseStatTotalWeighting = 0.5;
     public double baseStatHpWeighting = 0.5;
     public double baseStatAttWeighting = 0.5;
     public double baseStatDefWeighting = 0.5;

--- a/PokeAutobuilder/Shared/AutoBuilderDialog.razor
+++ b/PokeAutobuilder/Shared/AutoBuilderDialog.razor
@@ -92,7 +92,9 @@
 
             <MudDivider DividerType="DividerType.FullWidth" />
 
-            <MudText Typo="Typo.h6">Type Weightings</MudText>
+            <MudText Typo="Typo.h5">Generation Parameters</MudText>
+
+            <MudText Typo="Typo.h6">Types</MudText>
             <MudText Typo="Typo.subtitle1">Click a type to toggle it. Disabled types won't be considered during team generation.</MudText>
             <div>
                 @foreach (string t in Globals.AllTypes)
@@ -114,99 +116,124 @@
                 }
             </div>
 
-            <MudDivider DividerType="DividerType.FullWidth" />
-
-            <MudText Typo="Typo.h6">Balance Weightings</MudText>
-            <MudText Typo="Typo.subtitle1">Use the checkboxes and sliders to adjust the importance of different team attributes.</MudText>
             <MudGrid Spacing="2">
-                <MudItem xs="12" md="6">
+                <MudItem xs="12" md="6" lg="4">
+                    <MudText Typo="Typo.h6">Resistances</MudText>
+                    <MudText Typo="Typo.subtitle1">Use the sliders to fine-tune the importance of type resistances.</MudText>
                     <MudStack Class="px-2">
-                        <MudTooltip Text="Prioritise a team with at least one Pokémon resistant to each type." Placement="Placement.Bottom" RootClass="mud-width-full">
-                            <MudSlider @bind-Value="resistantAll" Size="Size.Medium" Min="0" Max="1" Step="0.05" Disabled="Generating">Resistant To All Types</MudSlider>
-                            @if (BestTeamScore is not null)
-                            {
-                                <MudProgressLinear Color="Color.Tertiary" Size="Size.Medium" Value="@BestTeamScore.ResistanceAll" Max="1.0" >
-                                    <MudText Typo="Typo.caption">@(String.Format("{0:0.00}", BestTeamScore.ResistanceAll * 100))%</MudText>
-                                </MudProgressLinear>
-                            }
-                        </MudTooltip>
-                        <MudTooltip Text="Prioritise a team with at least one Pokémon that has STAB coverage for each type." Placement="Placement.Bottom" RootClass="mud-width-full">
-                            <MudSlider @bind-Value="stabCoverageAll" Size="Size.Medium" Min="0" Max="1" Step="0.05" Disabled="Generating">STAB Against All Types</MudSlider>
-                            @if (BestTeamScore is not null)
-                            {
-                                <MudProgressLinear Color="Color.Tertiary" Size="Size.Medium" Value="@BestTeamScore.StabAll" Max="1.0">
-                                    <MudText Typo="Typo.caption">@(String.Format("{0:0.00}", BestTeamScore.StabAll * 100))%</MudText>
-                                </MudProgressLinear>
-                            }
-                        </MudTooltip>
-                        <MudTooltip Text="Weigh coverage higher on offensive Pokémon. E.g. a Pokémon with good offensive stats should also have good STAB coverage." Placement="Placement.Bottom" RootClass="mud-width-full">
-                            <MudSlider @bind-Value="coverageOnOffensive" Size="Size.Medium" Min="0" Max="1" Step="0.05" Disabled="Generating">Good Coverage On Offensive Pokémon</MudSlider>
-                            @if (BestTeamScore is not null)
-                            {
-                                <MudProgressLinear Color="Color.Tertiary" Size="Size.Medium" Value="@BestTeamScore.CoverageOnOffensive" Max="1.0">
-                                    <MudText Typo="Typo.caption">@(String.Format("{0:0.00}", BestTeamScore.CoverageOnOffensive * 100))%</MudText>
-                                </MudProgressLinear>
-                            }
-                        </MudTooltip>
-                        <MudTooltip Text="Weigh resistances higher on defensive Pokémon. E.g. a Pokémon with good defensive stats should also have good type resistances." Placement="Placement.Bottom" RootClass="mud-width-full">
-                            <MudSlider @bind-Value="resistancesOnDefensive" Size="Size.Medium" Min="0" Max="1" Step="0.05" Disabled="Generating">Good Resistances On Defensive Pokémon</MudSlider>
-                            @if (BestTeamScore is not null)
-                            {
-                                <MudProgressLinear Color="Color.Tertiary" Size="Size.Medium" Value="@BestTeamScore.ResistancesOnDefensive" Max="1.0">
-                                    <MudText Typo="Typo.caption">@(String.Format("{0:0.00}", BestTeamScore.ResistancesOnDefensive * 100))%</MudText>
-                                </MudProgressLinear>
-                            }
-                        </MudTooltip>
+                        <WeightingSlider Name="All Types"
+                                         Tooltip="Importance of a team with at least one Pokémon resistant to each type."
+                                         @bind-Value="resistanceAll" 
+                                         Score="BestTeamScore?.ResistanceAll"
+                                         Disabled="Generating"/>
+
+                        <WeightingSlider Name="Balance"
+                                         Tooltip="Importance of a balanced number of type resistances."
+                                         @bind-Value="resistanceBalance" 
+                                         Score="BestTeamScore?.ResistanceBalance"
+                                         Disabled="Generating"/>
+
+                        <WeightingSlider Name="Amount"
+                                         Tooltip="Importance of a higher amount of type resistances."
+                                         @bind-Value="resistanceAmount"
+                                         Score="BestTeamScore?.ResistanceAmount"
+                                         Disabled="Generating" />
                     </MudStack>
                 </MudItem>
-                <MudItem xs="12" md="6">
-                    <MudStack Class="px-2">
-                        <MudTooltip Text="Determines how important a good balance of moves is." Placement="Placement.Bottom" RootClass="mud-width-full">
-                            <MudSlider @bind-Value="moveSetBalanceWeighting" Size="Size.Medium" Min="0" Max="1" Step="0.05" Disabled="Generating">Balance Move Coverage</MudSlider>
-                            @if (BestTeamScore is not null)
-                            {
-                                <MudProgressLinear Color="Color.Tertiary" Size="Size.Medium" Value="@BestTeamScore.MoveSetBalance" Max="1.0">
-                                    <MudText Typo="Typo.caption">@(String.Format("{0:0.00}", BestTeamScore.MoveSetBalance * 100))%</MudText>
-                                </MudProgressLinear>
-                            }
-                        </MudTooltip>
-                        <MudTooltip Text="Determines how important a good balance of STAB coverage is." Placement="Placement.Bottom" RootClass="mud-width-full">
-                            <MudSlider @bind-Value="stabBalanceWeighting" Size="Size.Medium" Min="0" Max="1" Step="0.05" Disabled="Generating">Balance STAB Coverage</MudSlider>
-                            @if (BestTeamScore is not null)
-                            {
-                                <MudProgressLinear Color="Color.Tertiary" Size="Size.Medium" Value="@BestTeamScore.StabBalance" Max="1.0">
-                                    <MudText Typo="Typo.caption">@(String.Format("{0:0.00}", BestTeamScore.StabBalance * 100))%</MudText>
-                                </MudProgressLinear>
-                            }
-                        </MudTooltip>
-                        <MudTooltip Text="Determines how important a good balance of type resistances is." Placement="Placement.Bottom" RootClass="mud-width-full">
-                            <MudSlider @bind-Value="resistanceBalanceWeighting" Size="Size.Medium" Min="0" Max="1" Step="0.05" Disabled="Generating">Balance Resistances</MudSlider>
-                            @if (BestTeamScore is not null)
-                            {
-                                <MudProgressLinear Color="Color.Tertiary" Size="Size.Medium" Value="@BestTeamScore.ResistanceBalance" Max="1.0">
-                                    <MudText Typo="Typo.caption">@(String.Format("{0:0.00}", BestTeamScore.ResistanceBalance * 100))%</MudText>
-                                </MudProgressLinear>
-                            }
-                        </MudTooltip>
-                        <MudTooltip Text="Determines how important a good balance of type weakenesses is." Placement="Placement.Bottom" RootClass="mud-width-full">
-                            <MudSlider @bind-Value="weaknessBalanceWeighting" Size="Size.Medium" Min="0" Max="1" Step="0.05" Disabled="Generating">Balance Weaknesses</MudSlider>
-                            @if (BestTeamScore is not null)
-                            {
-                                <MudProgressLinear Color="Color.Tertiary" Size="Size.Medium" Value="@BestTeamScore.WeaknessBalance" Max="1.0">
-                                    <MudText Typo="Typo.caption">@(String.Format("{0:0.00}", BestTeamScore.WeaknessBalance * 100))%</MudText>
-                                </MudProgressLinear>
-                            }
-                        </MudTooltip>
+
+                <MudItem xs="12" md="6" lg="4">
+                    <MudText Typo="Typo.h6">Weaknesses</MudText>
+                    <MudText Typo="Typo.subtitle1">Use the sliders to fine-tune the importance of type weaknesses.</MudText>
+                    <MudStack Class="px-2 pt-8">
+
+                        <WeightingSlider Name="Balance"
+                                         Tooltip="Importance of a balanced number of type weaknesses."
+                                         @bind-Value="weaknessBalance"
+                                         Score="BestTeamScore?.WeaknessBalance"
+                                         Disabled="Generating" />
+
+                        <WeightingSlider Name="Amount"
+                                         Tooltip="Importance of a lower amount of type weaknesses."
+                                         @bind-Value="weaknessAmount"
+                                         Score="BestTeamScore?.WeaknessAmount"
+                                         Disabled="Generating" />
                     </MudStack>
                 </MudItem>
+
+                <MudItem xs="12" md="6" lg="4">
+                    <MudText Typo="Typo.h6">STAB Coverage</MudText>
+                    <MudText Typo="Typo.subtitle1">Use the sliders to fine-tune the importance of STAB coverage.</MudText>
+                    <MudStack Class="px-2">
+                        <WeightingSlider Name="All Types"
+                                         Tooltip="Importance of a team with at least one Pokémon with STAB coverage against each type."
+                                         @bind-Value="stabAll"
+                                         Score="BestTeamScore?.StabAll"
+                                         Disabled="Generating" />
+
+                        <WeightingSlider Name="Balance"
+                                         Tooltip="Importance of a balanced amount of STAB coverage."
+                                         @bind-Value="stabBalance"
+                                         Score="BestTeamScore?.StabBalance"
+                                         Disabled="Generating" />
+
+                        <WeightingSlider Name="Amount"
+                                         Tooltip="Importance of a higher amount of STAB coverage."
+                                         @bind-Value="stabAmount"
+                                         Score="BestTeamScore?.StabAmount"
+                                         Disabled="Generating" />
+                    </MudStack>
+                </MudItem>
+
+                <MudItem xs="12" md="6" lg="4">
+                    <MudText Typo="Typo.h6">Move Coverage</MudText>
+                    <MudText Typo="Typo.subtitle1">Use the sliders to fine-tune the importance of move coverage.</MudText>
+                    <MudStack Class="px-2">
+                        <WeightingSlider Name="All Types"
+                                         Tooltip="Importance of a team with at least one Pokémon with move coverage against each type."
+                                         @bind-Value="moveSetAll"
+                                         Score="BestTeamScore?.MoveSetAll"
+                                         Disabled="Generating" />
+
+                        <WeightingSlider Name="Balance"
+                                         Tooltip="Importance of a balanced amount of move coverage."
+                                         @bind-Value="moveSetBalance"
+                                         Score="BestTeamScore?.MoveSetBalance"
+                                         Disabled="Generating" />
+
+                        <WeightingSlider Name="Amount"
+                                         Tooltip="Importance of a higher amount of move coverage."
+                                         @bind-Value="moveSetAmount"
+                                         Score="BestTeamScore?.MoveSetAmount"
+                                         Disabled="Generating" />
+                    </MudStack>
+                </MudItem>
+
+                <MudItem xs="12" md="6" lg="4">
+                    <MudText Typo="Typo.h6">Miscellaneous</MudText>
+                    <MudText Typo="Typo.subtitle1">Use the sliders to fine-tune the importance of other misc. attributes.</MudText>
+                    <MudStack Class="px-2">
+                        <WeightingSlider Name="Good Coverage On Offensive Pokémon"
+                                         Tooltip="Importance of good coverage on offensive Pokémon. E.g. a Pokémon with good offensive stats should have STAB coverage against more types."
+                                         @bind-Value="coverageOnOffensive"
+                                         Score="BestTeamScore?.CoverageOnOffensive"
+                                         Disabled="Generating" />
+
+                        <WeightingSlider Name="Good Resistances On Defensive Pokémon"
+                                         Tooltip="Importance of good resistances on defensive Pokémon. E.g. a Pokémon with good defensive stats should also be resistant to more types."
+                                         @bind-Value="resistancesOnDefensive"
+                                         Score="BestTeamScore?.ResistancesOnDefensive"
+                                         Disabled="Generating" />
+                    </MudStack>
+                </MudItem>
+
                 <MudItem xs="12">
                     <MudDivider DividerType="DividerType.FullWidth" Class="my-2"/>
                     <MudText Typo="Typo.h6">Stat Weightings</MudText>
                     <MudText Typo="Typo.subtitle1">Use the sliders to adjust the importance of different base statistics. The big slider determines the importance of base statistics compared to the other weighting options.</MudText>
-                    <MudSlider @bind-Value="baseStatTotalWeighting" Size="Size.Large" Min="0" Max="1" Step="0.05" Disabled="Generating"></MudSlider>
+                    <MudSlider @bind-Value="baseStatTotal" Size="Size.Large" Min="0" Max="1" Step="0.05" Disabled="Generating"></MudSlider>
                     <MudGrid>
                         <MudItem xs="6" sm="4" md="2">
-                            <MudSlider @bind-Value="baseStatHpWeighting"    Size="Size.Small" Min="0" Max="1" Step="0.05" Disabled="Generating">HP</MudSlider>
+                            <MudSlider @bind-Value="baseStatHp"    Size="Size.Small" Min="0" Max="1" Step="0.05" Disabled="Generating">HP</MudSlider>
                             @if (BestTeamScore is not null)
                             {
                                 <MudProgressLinear Color="Color.Tertiary" Size="Size.Medium" Value="@BestTeamScore.BaseStatHp" Max="1.0">
@@ -215,7 +242,7 @@
                             }
                         </MudItem>
                         <MudItem xs="6" sm="4" md="2">
-                            <MudSlider @bind-Value="baseStatAttWeighting"   Size="Size.Small" Min="0" Max="1" Step="0.05" Disabled="Generating">Attack</MudSlider>
+                            <MudSlider @bind-Value="baseStatAtt"   Size="Size.Small" Min="0" Max="1" Step="0.05" Disabled="Generating">Attack</MudSlider>
                             @if (BestTeamScore is not null)
                             {
                                 <MudProgressLinear Color="Color.Tertiary" Size="Size.Medium" Value="@BestTeamScore.BaseStatAtt" Max="1.0">
@@ -224,7 +251,7 @@
                             }
                         </MudItem>
                         <MudItem xs="6" sm="4" md="2">
-                            <MudSlider @bind-Value="baseStatDefWeighting"   Size="Size.Small" Min="0" Max="1" Step="0.05" Disabled="Generating">Defense</MudSlider>
+                            <MudSlider @bind-Value="baseStatDef"   Size="Size.Small" Min="0" Max="1" Step="0.05" Disabled="Generating">Defense</MudSlider>
                             @if (BestTeamScore is not null)
                             {
                                 <MudProgressLinear Color="Color.Tertiary" Size="Size.Medium" Value="@BestTeamScore.BaseStatDef" Max="1.0">
@@ -233,7 +260,7 @@
                             }
                         </MudItem>
                         <MudItem xs="6" sm="4" md="2">
-                            <MudSlider @bind-Value="baseStatSpAttWeighting" Size="Size.Small" Min="0" Max="1" Step="0.05" Disabled="Generating">Sp. Attack</MudSlider>
+                            <MudSlider @bind-Value="baseStatSpAtt" Size="Size.Small" Min="0" Max="1" Step="0.05" Disabled="Generating">Sp. Attack</MudSlider>
                             @if (BestTeamScore is not null)
                             {
                                 <MudProgressLinear Color="Color.Tertiary" Size="Size.Medium" Value="@BestTeamScore.BaseStatSpAtt" Max="1.0">
@@ -242,7 +269,7 @@
                             }
                         </MudItem>
                         <MudItem xs="6" sm="4" md="2">
-                            <MudSlider @bind-Value="baseStatSpDefWeighting" Size="Size.Small" Min="0" Max="1" Step="0.05" Disabled="Generating">Sp. Defense</MudSlider>
+                            <MudSlider @bind-Value="baseStatSpDef" Size="Size.Small" Min="0" Max="1" Step="0.05" Disabled="Generating">Sp. Defense</MudSlider>
                             @if (BestTeamScore is not null)
                             {
                                 <MudProgressLinear Color="Color.Tertiary" Size="Size.Medium" Value="@BestTeamScore.BaseStatSpDef" Max="1.0">
@@ -251,7 +278,7 @@
                             }
                         </MudItem>
                         <MudItem xs="6" sm="4" md="2">
-                            <MudSlider @bind-Value="baseStatSpeWeighting"   Size="Size.Small" Min="0" Max="1" Step="0.05" Disabled="Generating">Speed</MudSlider>
+                            <MudSlider @bind-Value="baseStatSpe"   Size="Size.Small" Min="0" Max="1" Step="0.05" Disabled="Generating">Speed</MudSlider>
                             @if (BestTeamScore is not null)
                             {
                                 <MudProgressLinear Color="Color.Tertiary" Size="Size.Medium" Value="@BestTeamScore.BaseStatSpe" Max="1.0">
@@ -293,24 +320,32 @@
 
     public Dictionary<string, bool> typeWeightings = [];
 
-    public double resistantAll = 0.5;
-    public double stabCoverageAll = 0.5;
+    public double resistanceAll = 0.5;
+    public double resistanceBalance = 0.5;
+    public double resistanceAmount = 0.5;
+
+    public double weaknessBalance = 0.5;
+    public double weaknessAmount = 0.5;
+
+    public double stabAll = 0.5;
+    public double stabBalance = 0.5;
+    public double stabAmount = 0.5;
+
+    public double moveSetAll = 0.5;
+    public double moveSetBalance = 0.5;
+    public double moveSetAmount = 0.5;
+
     public double coverageOnOffensive = 0.0;
     public double resistancesOnDefensive = 0.0;
 
-    public double moveSetBalanceWeighting = 0.5;
-    public double stabBalanceWeighting = 0.5;
-    public double resistanceBalanceWeighting = 0.5;
-    public double weaknessBalanceWeighting = 0.5;
-
     // base stats
-    public double baseStatTotalWeighting = 0.5;
-    public double baseStatHpWeighting = 0.5;
-    public double baseStatAttWeighting = 0.5;
-    public double baseStatDefWeighting = 0.5;
-    public double baseStatSpAttWeighting = 0.5;
-    public double baseStatSpDefWeighting = 0.5;
-    public double baseStatSpeWeighting = 0.5;
+    public double baseStatTotal = 0.5;
+    public double baseStatHp = 0.5;
+    public double baseStatAtt = 0.5;
+    public double baseStatDef = 0.5;
+    public double baseStatSpAtt = 0.5;
+    public double baseStatSpDef = 0.5;
+    public double baseStatSpe = 0.5;
 
     protected override void OnAfterRender(bool firstRender)
     {
@@ -348,23 +383,32 @@
 
         AutoBuilderWeightings weightings = new AutoBuilderWeightings(
             typeWeightings
-            , resistantAll
-            , stabCoverageAll
-            , coverageOnOffensive
-            , resistancesOnDefensive
+            , resistanceAll: resistanceAll
+            , resistanceBalance: resistanceBalance
+            , resistanceAmount: resistanceAmount
 
-            , moveSetBalanceWeighting
-            , stabBalanceWeighting
-            , resistanceBalanceWeighting
-            , weaknessBalanceWeighting
+            , weaknessBalance: weaknessBalance
+            , weaknessAmount: weaknessAmount
+            
+            , stabAll: stabAll
+            , stabBalance: stabBalance
+            , stabAmount: stabAmount
 
-            , baseStatTotalWeighting
-            , baseStatHpWeighting
-            , baseStatAttWeighting
-            , baseStatDefWeighting
-            , baseStatSpAttWeighting
-            , baseStatSpDefWeighting
-            , baseStatSpeWeighting);
+            , moveSetAll: moveSetAll
+            , moveSetBalance: moveSetBalance
+            , moveSetAmount: moveSetAmount
+
+            , coverageOnOffensive: coverageOnOffensive
+            , resistancesOnDefensive: resistancesOnDefensive
+
+            , baseStatTotal: baseStatTotal
+            , baseStatHp: baseStatHp
+            , baseStatAtt: baseStatAtt
+            , baseStatDef: baseStatDef
+            , baseStatSpAtt: baseStatSpAtt
+            , baseStatSpDef: baseStatSpDef
+            , baseStatSpe: baseStatSpe
+            );
 
         GeneticAlgorithm.Initialize(
             PopulationSize

--- a/PokeAutobuilder/Shared/AutoBuilderDialog.razor
+++ b/PokeAutobuilder/Shared/AutoBuilderDialog.razor
@@ -123,15 +123,39 @@
                     <MudStack Class="px-2">
                         <MudTooltip Text="Prioritise a team with at least one Pokémon resistant to each type." Placement="Placement.Bottom" RootClass="mud-width-full">
                             <MudSlider @bind-Value="resistantAll" Size="Size.Medium" Min="0" Max="1" Step="0.05" Disabled="Generating">Resistant To All Types</MudSlider>
+                            @if (BestTeamScore is not null)
+                            {
+                                <MudProgressLinear Color="Color.Tertiary" Size="Size.Medium" Value="@BestTeamScore.ResistantAll" Max="1.0" >
+                                    <MudText Typo="Typo.caption">@(String.Format("{0:0.00}", BestTeamScore.ResistantAll * 100))%</MudText>
+                                </MudProgressLinear>
+                            }
                         </MudTooltip>
                         <MudTooltip Text="Prioritise a team with at least one Pokémon that has STAB coverage for each type." Placement="Placement.Bottom" RootClass="mud-width-full">
                             <MudSlider @bind-Value="stabCoverageAll" Size="Size.Medium" Min="0" Max="1" Step="0.05" Disabled="Generating">STAB Against All Types</MudSlider>
+                            @if (BestTeamScore is not null)
+                            {
+                                <MudProgressLinear Color="Color.Tertiary" Size="Size.Medium" Value="@BestTeamScore.STABCoverageAll" Max="1.0">
+                                    <MudText Typo="Typo.caption">@(String.Format("{0:0.00}", BestTeamScore.STABCoverageAll * 100))%</MudText>
+                                </MudProgressLinear>
+                            }
                         </MudTooltip>
                         <MudTooltip Text="Weigh coverage higher on offensive Pokémon. E.g. a Pokémon with good offensive stats should also have good STAB coverage." Placement="Placement.Bottom" RootClass="mud-width-full">
                             <MudSlider @bind-Value="coverageOnOffensive" Size="Size.Medium" Min="0" Max="1" Step="0.05" Disabled="Generating">Good Coverage On Offensive Pokémon</MudSlider>
+                            @if (BestTeamScore is not null)
+                            {
+                                <MudProgressLinear Color="Color.Tertiary" Size="Size.Medium" Value="@BestTeamScore.CoverageOnOffensive" Max="1.0">
+                                    <MudText Typo="Typo.caption">@(String.Format("{0:0.00}", BestTeamScore.CoverageOnOffensive * 100))%</MudText>
+                                </MudProgressLinear>
+                            }
                         </MudTooltip>
                         <MudTooltip Text="Weigh resistances higher on defensive Pokémon. E.g. a Pokémon with good defensive stats should also have good type resistances." Placement="Placement.Bottom" RootClass="mud-width-full">
                             <MudSlider @bind-Value="resistancesOnDefensive" Size="Size.Medium" Min="0" Max="1" Step="0.05" Disabled="Generating">Good Resistances On Defensive Pokémon</MudSlider>
+                            @if (BestTeamScore is not null)
+                            {
+                                <MudProgressLinear Color="Color.Tertiary" Size="Size.Medium" Value="@BestTeamScore.ResistancesOnDefensive" Max="1.0">
+                                    <MudText Typo="Typo.caption">@(String.Format("{0:0.00}", BestTeamScore.ResistancesOnDefensive * 100))%</MudText>
+                                </MudProgressLinear>
+                            }
                         </MudTooltip>
                     </MudStack>
                 </MudItem>
@@ -139,15 +163,39 @@
                     <MudStack Class="px-2">
                         <MudTooltip Text="Determines how important a good balance of moves is." Placement="Placement.Bottom" RootClass="mud-width-full">
                             <MudSlider @bind-Value="moveSetBalanceWeighting" Size="Size.Medium" Min="0" Max="1" Step="0.05" Disabled="Generating">Balance Move Coverage</MudSlider>
+                            @if (BestTeamScore is not null)
+                            {
+                                <MudProgressLinear Color="Color.Tertiary" Size="Size.Medium" Value="@BestTeamScore.MoveSetBalance" Max="1.0">
+                                    <MudText Typo="Typo.caption">@(String.Format("{0:0.00}", BestTeamScore.MoveSetBalance * 100))%</MudText>
+                                </MudProgressLinear>
+                            }
                         </MudTooltip>
                         <MudTooltip Text="Determines how important a good balance of STAB coverage is." Placement="Placement.Bottom" RootClass="mud-width-full">
                             <MudSlider @bind-Value="stabBalanceWeighting" Size="Size.Medium" Min="0" Max="1" Step="0.05" Disabled="Generating">Balance STAB Coverage</MudSlider>
+                            @if (BestTeamScore is not null)
+                            {
+                                <MudProgressLinear Color="Color.Tertiary" Size="Size.Medium" Value="@BestTeamScore.StabBalance" Max="1.0">
+                                    <MudText Typo="Typo.caption">@(String.Format("{0:0.00}", BestTeamScore.StabBalance * 100))%</MudText>
+                                </MudProgressLinear>
+                            }
                         </MudTooltip>
                         <MudTooltip Text="Determines how important a good balance of type resistances is." Placement="Placement.Bottom" RootClass="mud-width-full">
                             <MudSlider @bind-Value="resistanceBalanceWeighting" Size="Size.Medium" Min="0" Max="1" Step="0.05" Disabled="Generating">Balance Resistances</MudSlider>
+                            @if (BestTeamScore is not null)
+                            {
+                                <MudProgressLinear Color="Color.Tertiary" Size="Size.Medium" Value="@BestTeamScore.ResistanceBalance" Max="1.0">
+                                    <MudText Typo="Typo.caption">@(String.Format("{0:0.00}", BestTeamScore.ResistanceBalance * 100))%</MudText>
+                                </MudProgressLinear>
+                            }
                         </MudTooltip>
                         <MudTooltip Text="Determines how important a good balance of type weakenesses is." Placement="Placement.Bottom" RootClass="mud-width-full">
                             <MudSlider @bind-Value="weaknessBalanceWeighting" Size="Size.Medium" Min="0" Max="1" Step="0.05" Disabled="Generating">Balance Weaknesses</MudSlider>
+                            @if (BestTeamScore is not null)
+                            {
+                                <MudProgressLinear Color="Color.Tertiary" Size="Size.Medium" Value="@BestTeamScore.WeaknessBalance" Max="1.0">
+                                    <MudText Typo="Typo.caption">@(String.Format("{0:0.00}", BestTeamScore.WeaknessBalance * 100))%</MudText>
+                                </MudProgressLinear>
+                            }
                         </MudTooltip>
                     </MudStack>
                 </MudItem>
@@ -157,12 +205,60 @@
                     <MudText Typo="Typo.subtitle1">Use the sliders to adjust the importance of different base statistics. The big slider determines the importance of base statistics compared to the other weighting options.</MudText>
                     <MudSlider @bind-Value="baseStatTotalWeighting" Size="Size.Large" Min="0" Max="1" Step="0.05" Disabled="Generating"></MudSlider>
                     <MudGrid>
-                        <MudItem xs="6" sm="4" md="2"><MudSlider @bind-Value="baseStatHpWeighting"    Size="Size.Small" Min="0" Max="1" Step="0.05" Disabled="Generating">HP</MudSlider>           </MudItem>
-                        <MudItem xs="6" sm="4" md="2"><MudSlider @bind-Value="baseStatAttWeighting"   Size="Size.Small" Min="0" Max="1" Step="0.05" Disabled="Generating">Attack</MudSlider>       </MudItem>
-                        <MudItem xs="6" sm="4" md="2"><MudSlider @bind-Value="baseStatDefWeighting"   Size="Size.Small" Min="0" Max="1" Step="0.05" Disabled="Generating">Defense</MudSlider>      </MudItem>
-                        <MudItem xs="6" sm="4" md="2"><MudSlider @bind-Value="baseStatSpAttWeighting" Size="Size.Small" Min="0" Max="1" Step="0.05" Disabled="Generating">Sp. Attack</MudSlider>   </MudItem>
-                        <MudItem xs="6" sm="4" md="2"><MudSlider @bind-Value="baseStatSpDefWeighting" Size="Size.Small" Min="0" Max="1" Step="0.05" Disabled="Generating">Sp. Defense</MudSlider>  </MudItem>
-                        <MudItem xs="6" sm="4" md="2"><MudSlider @bind-Value="baseStatSpeWeighting"   Size="Size.Small" Min="0" Max="1" Step="0.05" Disabled="Generating">Speed</MudSlider>        </MudItem>
+                        <MudItem xs="6" sm="4" md="2">
+                            <MudSlider @bind-Value="baseStatHpWeighting"    Size="Size.Small" Min="0" Max="1" Step="0.05" Disabled="Generating">HP</MudSlider>
+                            @if (BestTeamScore is not null)
+                            {
+                                <MudProgressLinear Color="Color.Tertiary" Size="Size.Medium" Value="@BestTeamScore.BaseStatHp" Max="1.0">
+                                    <MudText Typo="Typo.caption">@(String.Format("{0:0.00}", BestTeamScore.BaseStatHp * 100))%</MudText>
+                                </MudProgressLinear>
+                            }
+                        </MudItem>
+                        <MudItem xs="6" sm="4" md="2">
+                            <MudSlider @bind-Value="baseStatAttWeighting"   Size="Size.Small" Min="0" Max="1" Step="0.05" Disabled="Generating">Attack</MudSlider>
+                            @if (BestTeamScore is not null)
+                            {
+                                <MudProgressLinear Color="Color.Tertiary" Size="Size.Medium" Value="@BestTeamScore.BaseStatAtt" Max="1.0">
+                                    <MudText Typo="Typo.caption">@(String.Format("{0:0.00}", BestTeamScore.BaseStatAtt * 100))%</MudText>
+                                </MudProgressLinear>
+                            }
+                        </MudItem>
+                        <MudItem xs="6" sm="4" md="2">
+                            <MudSlider @bind-Value="baseStatDefWeighting"   Size="Size.Small" Min="0" Max="1" Step="0.05" Disabled="Generating">Defense</MudSlider>
+                            @if (BestTeamScore is not null)
+                            {
+                                <MudProgressLinear Color="Color.Tertiary" Size="Size.Medium" Value="@BestTeamScore.BaseStatDef" Max="1.0">
+                                    <MudText Typo="Typo.caption">@(String.Format("{0:0.00}", BestTeamScore.BaseStatDef * 100))%</MudText>
+                                </MudProgressLinear>
+                            }
+                        </MudItem>
+                        <MudItem xs="6" sm="4" md="2">
+                            <MudSlider @bind-Value="baseStatSpAttWeighting" Size="Size.Small" Min="0" Max="1" Step="0.05" Disabled="Generating">Sp. Attack</MudSlider>
+                            @if (BestTeamScore is not null)
+                            {
+                                <MudProgressLinear Color="Color.Tertiary" Size="Size.Medium" Value="@BestTeamScore.BaseStatSpAtt" Max="1.0">
+                                    <MudText Typo="Typo.caption">@(String.Format("{0:0.00}", BestTeamScore.BaseStatSpAtt * 100))%</MudText>
+                                </MudProgressLinear>
+                            }
+                        </MudItem>
+                        <MudItem xs="6" sm="4" md="2">
+                            <MudSlider @bind-Value="baseStatSpDefWeighting" Size="Size.Small" Min="0" Max="1" Step="0.05" Disabled="Generating">Sp. Defense</MudSlider>
+                            @if (BestTeamScore is not null)
+                            {
+                                <MudProgressLinear Color="Color.Tertiary" Size="Size.Medium" Value="@BestTeamScore.BaseStatSpDef" Max="1.0">
+                                    <MudText Typo="Typo.caption">@(String.Format("{0:0.00}", BestTeamScore.BaseStatSpDef * 100))%</MudText>
+                                </MudProgressLinear>
+                            }
+                        </MudItem>
+                        <MudItem xs="6" sm="4" md="2">
+                            <MudSlider @bind-Value="baseStatSpeWeighting"   Size="Size.Small" Min="0" Max="1" Step="0.05" Disabled="Generating">Speed</MudSlider>
+                            @if (BestTeamScore is not null)
+                            {
+                                <MudProgressLinear Color="Color.Tertiary" Size="Size.Medium" Value="@BestTeamScore.BaseStatSpe" Max="1.0">
+                                    <MudText Typo="Typo.caption">@(String.Format("{0:0.00}", BestTeamScore.BaseStatSpe * 100))%</MudText>
+                                </MudProgressLinear>
+                            }
+                        </MudItem>
                     </MudGrid>
                 </MudItem>
             </MudGrid>
@@ -183,6 +279,7 @@
 
     private PokemonTeamGeneticAlgorithm GeneticAlgorithm = new PokemonTeamGeneticAlgorithm();
     private PokemonTeam BestTeam = new PokemonTeam();
+    private AutoBuilderWeightings? BestTeamScore;
 
     private bool Generating = false;
     private int GenerationsRan { get; set; } = 0;
@@ -290,6 +387,7 @@
     public void OnClickReset()
     {
         BestTeam = new PokemonTeam();
+        BestTeamScore = null;
         StateHasChanged();
     }
 
@@ -311,6 +409,7 @@
         if (GABestChromFitness > BestOverallFitness)
         {
             BestTeam = GeneratedTeam;
+            BestTeamScore = geneticAlgorithm.BestChromosome.WeightingScores;
             BestOverallFitness = (double)GABestChromFitness;
         }
 

--- a/PokeAutobuilder/Shared/AutoBuilderDialog.razor
+++ b/PokeAutobuilder/Shared/AutoBuilderDialog.razor
@@ -125,8 +125,8 @@
                             <MudSlider @bind-Value="resistantAll" Size="Size.Medium" Min="0" Max="1" Step="0.05" Disabled="Generating">Resistant To All Types</MudSlider>
                             @if (BestTeamScore is not null)
                             {
-                                <MudProgressLinear Color="Color.Tertiary" Size="Size.Medium" Value="@BestTeamScore.ResistantAll" Max="1.0" >
-                                    <MudText Typo="Typo.caption">@(String.Format("{0:0.00}", BestTeamScore.ResistantAll * 100))%</MudText>
+                                <MudProgressLinear Color="Color.Tertiary" Size="Size.Medium" Value="@BestTeamScore.ResistanceAll" Max="1.0" >
+                                    <MudText Typo="Typo.caption">@(String.Format("{0:0.00}", BestTeamScore.ResistanceAll * 100))%</MudText>
                                 </MudProgressLinear>
                             }
                         </MudTooltip>
@@ -134,8 +134,8 @@
                             <MudSlider @bind-Value="stabCoverageAll" Size="Size.Medium" Min="0" Max="1" Step="0.05" Disabled="Generating">STAB Against All Types</MudSlider>
                             @if (BestTeamScore is not null)
                             {
-                                <MudProgressLinear Color="Color.Tertiary" Size="Size.Medium" Value="@BestTeamScore.STABCoverageAll" Max="1.0">
-                                    <MudText Typo="Typo.caption">@(String.Format("{0:0.00}", BestTeamScore.STABCoverageAll * 100))%</MudText>
+                                <MudProgressLinear Color="Color.Tertiary" Size="Size.Medium" Value="@BestTeamScore.StabAll" Max="1.0">
+                                    <MudText Typo="Typo.caption">@(String.Format("{0:0.00}", BestTeamScore.StabAll * 100))%</MudText>
                                 </MudProgressLinear>
                             }
                         </MudTooltip>

--- a/PokeAutobuilder/Shared/AutoBuilderDialog.razor
+++ b/PokeAutobuilder/Shared/AutoBuilderDialog.razor
@@ -104,7 +104,7 @@
                         {
                             <MudImage Src="@StringUtils.DisabledTypeImgFromName(t)" Alt="@t" title="@t" Height="40" Class="ma-1" />
                         }
-                        else if (typeWeightings.ContainsKey(t) && typeWeightings[t])
+                        else if (GenerationParameters.Types.ContainsKey(t) && GenerationParameters.Types[t])
                         {
                             <MudImage Src="@StringUtils.TypeImgFromName(t)" Alt="@t" title="@t" Height="40" Class="ma-1" />
                         }
@@ -123,19 +123,19 @@
                     <MudStack Class="px-2">
                         <WeightingSlider Name="All Types"
                                          Tooltip="Importance of a team with at least one Pokémon resistant to each type."
-                                         @bind-Value="resistanceAll" 
+                                         @bind-Value="GenerationParameters.ResistanceAll"
                                          Score="BestTeamScore?.ResistanceAll"
                                          Disabled="Generating"/>
 
                         <WeightingSlider Name="Balance"
                                          Tooltip="Importance of a balanced number of type resistances."
-                                         @bind-Value="resistanceBalance" 
+                                         @bind-Value="GenerationParameters.ResistanceBalance"
                                          Score="BestTeamScore?.ResistanceBalance"
                                          Disabled="Generating"/>
 
                         <WeightingSlider Name="Amount"
                                          Tooltip="Importance of a higher amount of type resistances."
-                                         @bind-Value="resistanceAmount"
+                                         @bind-Value="GenerationParameters.ResistanceAmount"
                                          Score="BestTeamScore?.ResistanceAmount"
                                          Disabled="Generating" />
                     </MudStack>
@@ -147,13 +147,13 @@
                     <MudStack Class="px-2">
                         <WeightingSlider Name="Balance"
                                          Tooltip="Importance of a balanced number of type weaknesses."
-                                         @bind-Value="weaknessBalance"
+                                         @bind-Value="GenerationParameters.WeaknessBalance"
                                          Score="BestTeamScore?.WeaknessBalance"
                                          Disabled="Generating" />
 
                         <WeightingSlider Name="Amount"
                                          Tooltip="Importance of a lower amount of type weaknesses."
-                                         @bind-Value="weaknessAmount"
+                                         @bind-Value="GenerationParameters.WeaknessAmount"
                                          Score="BestTeamScore?.WeaknessAmount"
                                          Disabled="Generating" />
                     </MudStack>
@@ -165,19 +165,19 @@
                     <MudStack Class="px-2">
                         <WeightingSlider Name="All Types"
                                          Tooltip="Importance of a team with at least one Pokémon with STAB coverage against each type."
-                                         @bind-Value="stabAll"
+                                         @bind-Value="GenerationParameters.StabAll"
                                          Score="BestTeamScore?.StabAll"
                                          Disabled="Generating" />
 
                         <WeightingSlider Name="Balance"
                                          Tooltip="Importance of a balanced amount of STAB coverage."
-                                         @bind-Value="stabBalance"
+                                         @bind-Value="GenerationParameters.StabBalance"
                                          Score="BestTeamScore?.StabBalance"
                                          Disabled="Generating" />
 
                         <WeightingSlider Name="Amount"
                                          Tooltip="Importance of a higher amount of STAB coverage."
-                                         @bind-Value="stabAmount"
+                                         @bind-Value="GenerationParameters.StabAmount"
                                          Score="BestTeamScore?.StabAmount"
                                          Disabled="Generating" />
                     </MudStack>
@@ -189,19 +189,19 @@
                     <MudStack Class="px-2">
                         <WeightingSlider Name="All Types"
                                          Tooltip="Importance of a team with at least one Pokémon with move coverage against each type."
-                                         @bind-Value="moveSetAll"
+                                         @bind-Value="GenerationParameters.MoveSetAll"
                                          Score="BestTeamScore?.MoveSetAll"
                                          Disabled="Generating" />
 
                         <WeightingSlider Name="Balance"
                                          Tooltip="Importance of a balanced amount of move coverage."
-                                         @bind-Value="moveSetBalance"
+                                         @bind-Value="GenerationParameters.MoveSetBalance"
                                          Score="BestTeamScore?.MoveSetBalance"
                                          Disabled="Generating" />
 
                         <WeightingSlider Name="Amount"
                                          Tooltip="Importance of a higher amount of move coverage."
-                                         @bind-Value="moveSetAmount"
+                                         @bind-Value="GenerationParameters.MoveSetAmount"
                                          Score="BestTeamScore?.MoveSetAmount"
                                          Disabled="Generating" />
                     </MudStack>
@@ -213,13 +213,13 @@
                     <MudStack Class="px-2">
                         <WeightingSlider Name="Good Coverage On Offensive Pokémon"
                                          Tooltip="Importance of good coverage on offensive Pokémon. E.g. a Pokémon with good offensive stats should have STAB coverage against more types."
-                                         @bind-Value="coverageOnOffensive"
+                                         @bind-Value="GenerationParameters.CoverageOnOffensive"
                                          Score="BestTeamScore?.CoverageOnOffensive"
                                          Disabled="Generating" />
 
                         <WeightingSlider Name="Good Resistances On Defensive Pokémon"
                                          Tooltip="Importance of good resistances on defensive Pokémon. E.g. a Pokémon with good defensive stats should also be resistant to more types."
-                                         @bind-Value="resistancesOnDefensive"
+                                         @bind-Value="GenerationParameters.ResistancesOnDefensive"
                                          Score="BestTeamScore?.ResistancesOnDefensive"
                                          Disabled="Generating" />
                     </MudStack>
@@ -229,10 +229,10 @@
                     <MudDivider DividerType="DividerType.FullWidth" Class="my-2"/>
                     <MudText Typo="Typo.h6">Stat Weightings</MudText>
                     <MudText Typo="Typo.subtitle1">Use the sliders to adjust the importance of different base statistics. The big slider determines the importance of base statistics compared to the other weighting options.</MudText>
-                    <MudSlider @bind-Value="baseStatTotal" Size="Size.Large" Min="0" Max="1" Step="0.05" Disabled="Generating"></MudSlider>
+                    <MudSlider @bind-Value="GenerationParameters.BaseStatTotal" Size="Size.Large" Min="0" Max="1" Step="0.05" Disabled="Generating"></MudSlider>
                     <MudGrid>
                         <MudItem xs="6" sm="4" md="2">
-                            <MudSlider @bind-Value="baseStatHp"    Size="Size.Small" Min="0" Max="1" Step="0.05" Disabled="Generating">HP</MudSlider>
+                            <MudSlider @bind-Value="GenerationParameters.BaseStatHp" Size="Size.Small" Min="0" Max="1" Step="0.05" Disabled="Generating">HP</MudSlider>
                             @if (BestTeamScore is not null)
                             {
                                 <MudProgressLinear Color="Color.Tertiary" Size="Size.Medium" Value="@BestTeamScore.BaseStatHp" Max="1.0">
@@ -241,7 +241,7 @@
                             }
                         </MudItem>
                         <MudItem xs="6" sm="4" md="2">
-                            <MudSlider @bind-Value="baseStatAtt"   Size="Size.Small" Min="0" Max="1" Step="0.05" Disabled="Generating">Attack</MudSlider>
+                            <MudSlider @bind-Value="GenerationParameters.BaseStatAtt"   Size="Size.Small" Min="0" Max="1" Step="0.05" Disabled="Generating">Attack</MudSlider>
                             @if (BestTeamScore is not null)
                             {
                                 <MudProgressLinear Color="Color.Tertiary" Size="Size.Medium" Value="@BestTeamScore.BaseStatAtt" Max="1.0">
@@ -250,7 +250,7 @@
                             }
                         </MudItem>
                         <MudItem xs="6" sm="4" md="2">
-                            <MudSlider @bind-Value="baseStatDef"   Size="Size.Small" Min="0" Max="1" Step="0.05" Disabled="Generating">Defense</MudSlider>
+                            <MudSlider @bind-Value="GenerationParameters.BaseStatDef"   Size="Size.Small" Min="0" Max="1" Step="0.05" Disabled="Generating">Defense</MudSlider>
                             @if (BestTeamScore is not null)
                             {
                                 <MudProgressLinear Color="Color.Tertiary" Size="Size.Medium" Value="@BestTeamScore.BaseStatDef" Max="1.0">
@@ -259,7 +259,7 @@
                             }
                         </MudItem>
                         <MudItem xs="6" sm="4" md="2">
-                            <MudSlider @bind-Value="baseStatSpAtt" Size="Size.Small" Min="0" Max="1" Step="0.05" Disabled="Generating">Sp. Attack</MudSlider>
+                            <MudSlider @bind-Value="GenerationParameters.BaseStatSpAtt" Size="Size.Small" Min="0" Max="1" Step="0.05" Disabled="Generating">Sp. Attack</MudSlider>
                             @if (BestTeamScore is not null)
                             {
                                 <MudProgressLinear Color="Color.Tertiary" Size="Size.Medium" Value="@BestTeamScore.BaseStatSpAtt" Max="1.0">
@@ -268,7 +268,7 @@
                             }
                         </MudItem>
                         <MudItem xs="6" sm="4" md="2">
-                            <MudSlider @bind-Value="baseStatSpDef" Size="Size.Small" Min="0" Max="1" Step="0.05" Disabled="Generating">Sp. Defense</MudSlider>
+                            <MudSlider @bind-Value="GenerationParameters.BaseStatSpDef" Size="Size.Small" Min="0" Max="1" Step="0.05" Disabled="Generating">Sp. Defense</MudSlider>
                             @if (BestTeamScore is not null)
                             {
                                 <MudProgressLinear Color="Color.Tertiary" Size="Size.Medium" Value="@BestTeamScore.BaseStatSpDef" Max="1.0">
@@ -277,7 +277,7 @@
                             }
                         </MudItem>
                         <MudItem xs="6" sm="4" md="2">
-                            <MudSlider @bind-Value="baseStatSpe"   Size="Size.Small" Min="0" Max="1" Step="0.05" Disabled="Generating">Speed</MudSlider>
+                            <MudSlider @bind-Value="GenerationParameters.BaseStatSpe"   Size="Size.Small" Min="0" Max="1" Step="0.05" Disabled="Generating">Speed</MudSlider>
                             @if (BestTeamScore is not null)
                             {
                                 <MudProgressLinear Color="Color.Tertiary" Size="Size.Medium" Value="@BestTeamScore.BaseStatSpe" Max="1.0">
@@ -317,39 +317,45 @@
     private double? GABestChromFitness = 0;
     private double BestOverallFitness = 0;
 
-    public Dictionary<string, bool> typeWeightings = [];
+    public AutoBuilderWeightings GenerationParameters = new(
+            AutoBuilderWeightings.MakeDefaultTypeWeightings()
+            , resistanceAll: 0.5
+            , resistanceBalance: 0.5
+            , resistanceAmount: 0.5
 
-    public double resistanceAll = 0.5;
-    public double resistanceBalance = 0.5;
-    public double resistanceAmount = 0.5;
+            , weaknessBalance: 0.5
+            , weaknessAmount: 0.5
 
-    public double weaknessBalance = 0.5;
-    public double weaknessAmount = 0.5;
+            , stabAll: 0.5
+            , stabBalance: 0.5
+            , stabAmount: 0.5
 
-    public double stabAll = 0.5;
-    public double stabBalance = 0.5;
-    public double stabAmount = 0.5;
+            , moveSetAll: 0.5
+            , moveSetBalance: 0.5
+            , moveSetAmount: 0.5
 
-    public double moveSetAll = 0.5;
-    public double moveSetBalance = 0.5;
-    public double moveSetAmount = 0.5;
+            , coverageOnOffensive: 0.0
+            , resistancesOnDefensive: 0.0
 
-    public double coverageOnOffensive = 0.0;
-    public double resistancesOnDefensive = 0.0;
-
-    // base stats
-    public double baseStatTotal = 0.5;
-    public double baseStatHp = 0.5;
-    public double baseStatAtt = 0.5;
-    public double baseStatDef = 0.5;
-    public double baseStatSpAtt = 0.5;
-    public double baseStatSpDef = 0.5;
-    public double baseStatSpe = 0.5;
+            , baseStatTotal: 0.5
+            , baseStatHp: 0.5
+            , baseStatAtt: 0.5
+            , baseStatDef: 0.5
+            , baseStatSpAtt: 0.5
+            , baseStatSpDef: 0.5
+            , baseStatSpe: 0.5
+    );
 
     protected override void OnAfterRender(bool firstRender)
     {
         if (firstRender)
         {
+            // load the parameters from the current session
+            if (Session.AutobuilderParams is not null)
+            {
+                GenerationParameters = Session.AutobuilderParams;
+            }
+
             // set generation ran callback event
             GeneticAlgorithm.GenerationRan += HandleGenerationRan;
 
@@ -357,19 +363,9 @@
         }
     }
 
-    protected override void OnParametersSet()
-    {
-        // initialise type weightings list
-        foreach (string t in Globals.AllTypes)
-        {
-            typeWeightings[t] = true;
-        }
-        base.OnParametersSet();
-    }
-
     public void OnClickType(string typeName)
     {
-        typeWeightings[typeName] = !typeWeightings[typeName];
+        GenerationParameters.Types[typeName] = !GenerationParameters.Types[typeName];
         StateHasChanged();
     }
 
@@ -380,40 +376,13 @@
         ProgressValue = 0;
         BestOverallFitness = 0;
 
-        AutoBuilderWeightings weightings = new AutoBuilderWeightings(
-            typeWeightings
-            , resistanceAll: resistanceAll
-            , resistanceBalance: resistanceBalance
-            , resistanceAmount: resistanceAmount
-
-            , weaknessBalance: weaknessBalance
-            , weaknessAmount: weaknessAmount
-            
-            , stabAll: stabAll
-            , stabBalance: stabBalance
-            , stabAmount: stabAmount
-
-            , moveSetAll: moveSetAll
-            , moveSetBalance: moveSetBalance
-            , moveSetAmount: moveSetAmount
-
-            , coverageOnOffensive: coverageOnOffensive
-            , resistancesOnDefensive: resistancesOnDefensive
-
-            , baseStatTotal: baseStatTotal
-            , baseStatHp: baseStatHp
-            , baseStatAtt: baseStatAtt
-            , baseStatDef: baseStatDef
-            , baseStatSpAtt: baseStatSpAtt
-            , baseStatSpDef: baseStatSpDef
-            , baseStatSpe: baseStatSpe
-            );
+        AutoBuilderWeightings weightingsCopy = new(GenerationParameters);
 
         GeneticAlgorithm.Initialize(
             PopulationSize
             , Profile.PokemonStorage
             , LockedMembers is null ? new PokemonTeam() : LockedMembers
-            , weightings);
+            , weightingsCopy);
         GeneticAlgorithm.RunInBackground();
 
         StateHasChanged();
@@ -437,6 +406,7 @@
     public async Task OnClickLoadIntoEditor()
     {
         await Session.SetTeamAsync(BestTeam);
+        await Session.SetAutobuilderParams(GenerationParameters);
         MudDialog!.Close(DialogResult.Ok(true));
     }
 
@@ -470,9 +440,10 @@
         StateHasChanged();
     }
 
-    void Submit() 
+    async Task Submit() 
     {
         GeneticAlgorithm.Stop();
+        await Session.SetAutobuilderParams(GenerationParameters);
         MudDialog!.Close(DialogResult.Ok(true)); 
     }
     void Cancel() 

--- a/PokeAutobuilder/Shared/AutoBuilderDialog.razor
+++ b/PokeAutobuilder/Shared/AutoBuilderDialog.razor
@@ -96,9 +96,13 @@
             <MudText Typo="Typo.subtitle1">Click a type to toggle it. Disabled types won't be considered during team generation.</MudText>
             <div>
                 @foreach (string t in Globals.AllTypes)
-                {                    
-                    <MudButton OnClick="() => OnClickType(t)" Style="height: 50px;">
-                        @if (typeWeightings.ContainsKey(t) && typeWeightings[t])
+                {
+                    <MudButton OnClick="() => OnClickType(t)" Style="height: 50px;" Disabled="Generating">
+                        @if (Generating)
+                        {
+                            <MudImage Src="@StringUtils.DisabledTypeImgFromName(t)" Alt="@t" title="@t" Height="40" Class="ma-1" />
+                        }
+                        else if (typeWeightings.ContainsKey(t) && typeWeightings[t])
                         {
                             <MudImage Src="@StringUtils.TypeImgFromName(t)" Alt="@t" title="@t" Height="40" Class="ma-1" />
                         }
@@ -118,32 +122,32 @@
                 <MudItem xs="12" md="6">
                     <MudStack Class="px-1">
                         <MudTooltip Text="Prioritise a team with at least one Pokémon resistant to each type." Placement="Placement.Bottom" RootClass="mud-width-full">
-                            <MudSlider @bind-Value="resistantAll" Size="Size.Medium" Min="0" Max="1" Step="0.05">Resistant To All Types</MudSlider>
+                            <MudSlider @bind-Value="resistantAll" Size="Size.Medium" Min="0" Max="1" Step="0.05" Disabled="Generating">Resistant To All Types</MudSlider>
                         </MudTooltip>
                         <MudTooltip Text="Prioritise a team with at least one Pokémon that has STAB coverage for each type." Placement="Placement.Bottom" RootClass="mud-width-full">
-                            <MudSlider @bind-Value="stabCoverageAll" Size="Size.Medium" Min="0" Max="1" Step="0.05">STAB Against All Types</MudSlider>
+                            <MudSlider @bind-Value="stabCoverageAll" Size="Size.Medium" Min="0" Max="1" Step="0.05" Disabled="Generating">STAB Against All Types</MudSlider>
                         </MudTooltip>
                         <MudTooltip Text="Weigh coverage higher on offensive Pokémon. E.g. a Pokémon with good offensive stats should also have good STAB coverage." Placement="Placement.Bottom" RootClass="mud-width-full">
-                            <MudSlider @bind-Value="coverageOnOffensive" Size="Size.Medium" Min="0" Max="1" Step="0.05">Good Coverage On Offensive Pokémon</MudSlider>
+                            <MudSlider @bind-Value="coverageOnOffensive" Size="Size.Medium" Min="0" Max="1" Step="0.05" Disabled="Generating">Good Coverage On Offensive Pokémon</MudSlider>
                         </MudTooltip>
                         <MudTooltip Text="Weigh resistances higher on defensive Pokémon. E.g. a Pokémon with good defensive stats should also have good type resistances." Placement="Placement.Bottom" RootClass="mud-width-full">
-                            <MudSlider @bind-Value="resistancesOnDefensive" Size="Size.Medium" Min="0" Max="1" Step="0.05">Good Resistances On Defensive Pokémon</MudSlider>
+                            <MudSlider @bind-Value="resistancesOnDefensive" Size="Size.Medium" Min="0" Max="1" Step="0.05" Disabled="Generating">Good Resistances On Defensive Pokémon</MudSlider>
                         </MudTooltip>
                     </MudStack>
                 </MudItem>
                 <MudItem xs="12" md="6">
                     <MudStack Class="px-1">
                         <MudTooltip Text="Determines how important a good balance of moves is." Placement="Placement.Bottom" RootClass="mud-width-full">
-                            <MudSlider @bind-Value="moveSetBalanceWeighting" Size="Size.Medium" Min="0" Max="1" Step="0.05">Balance Move Coverage</MudSlider>
+                            <MudSlider @bind-Value="moveSetBalanceWeighting" Size="Size.Medium" Min="0" Max="1" Step="0.05" Disabled="Generating">Balance Move Coverage</MudSlider>
                         </MudTooltip>
                         <MudTooltip Text="Determines how important a good balance of STAB coverage is." Placement="Placement.Bottom" RootClass="mud-width-full">
-                            <MudSlider @bind-Value="stabBalanceWeighting" Size="Size.Medium" Min="0" Max="1" Step="0.05">Balance STAB Coverage</MudSlider>
+                            <MudSlider @bind-Value="stabBalanceWeighting" Size="Size.Medium" Min="0" Max="1" Step="0.05" Disabled="Generating">Balance STAB Coverage</MudSlider>
                         </MudTooltip>
                         <MudTooltip Text="Determines how important a good balance of type resistances is." Placement="Placement.Bottom" RootClass="mud-width-full">
-                            <MudSlider @bind-Value="resistanceBalanceWeighting" Size="Size.Medium" Min="0" Max="1" Step="0.05">Balance Resistances</MudSlider>
+                            <MudSlider @bind-Value="resistanceBalanceWeighting" Size="Size.Medium" Min="0" Max="1" Step="0.05" Disabled="Generating">Balance Resistances</MudSlider>
                         </MudTooltip>
                         <MudTooltip Text="Determines how important a good balance of type weakenesses is." Placement="Placement.Bottom" RootClass="mud-width-full">
-                            <MudSlider @bind-Value="weaknessBalanceWeighting" Size="Size.Medium" Min="0" Max="1" Step="0.05">Balance Weaknesses</MudSlider>
+                            <MudSlider @bind-Value="weaknessBalanceWeighting" Size="Size.Medium" Min="0" Max="1" Step="0.05" Disabled="Generating">Balance Weaknesses</MudSlider>
                         </MudTooltip>
                     </MudStack>
                 </MudItem>
@@ -151,14 +155,14 @@
                     <MudDivider DividerType="DividerType.FullWidth" Class="my-2"/>
                     <MudText Typo="Typo.h6">Stat Weightings</MudText>
                     <MudText Typo="Typo.subtitle1">Use the sliders to adjust the importance of different base statistics. The big slider determines the importance of base statistics compared to the other weighting options.</MudText>
-                    <MudSlider @bind-Value="baseStatTotalWeighting" Size="Size.Large" Min="0" Max="1" Step="0.05"></MudSlider>
+                    <MudSlider @bind-Value="baseStatTotalWeighting" Size="Size.Large" Min="0" Max="1" Step="0.05" Disabled="Generating"></MudSlider>
                     <MudGrid>
-                        <MudItem xs="6" sm="4" md="2"><MudSlider @bind-Value="baseStatHpWeighting"    Size="Size.Small" Min="0" Max="1" Step="0.05">HP</MudSlider>           </MudItem>
-                        <MudItem xs="6" sm="4" md="2"><MudSlider @bind-Value="baseStatAttWeighting"   Size="Size.Small" Min="0" Max="1" Step="0.05">Attack</MudSlider>       </MudItem>
-                        <MudItem xs="6" sm="4" md="2"><MudSlider @bind-Value="baseStatDefWeighting"   Size="Size.Small" Min="0" Max="1" Step="0.05">Defense</MudSlider>      </MudItem>
-                        <MudItem xs="6" sm="4" md="2"><MudSlider @bind-Value="baseStatSpAttWeighting" Size="Size.Small" Min="0" Max="1" Step="0.05">Sp. Attack</MudSlider>   </MudItem>
-                        <MudItem xs="6" sm="4" md="2"><MudSlider @bind-Value="baseStatSpDefWeighting" Size="Size.Small" Min="0" Max="1" Step="0.05">Sp. Defense</MudSlider>  </MudItem>
-                        <MudItem xs="6" sm="4" md="2"><MudSlider @bind-Value="baseStatSpeWeighting"   Size="Size.Small" Min="0" Max="1" Step="0.05">Speed</MudSlider>        </MudItem>
+                        <MudItem xs="6" sm="4" md="2"><MudSlider @bind-Value="baseStatHpWeighting"    Size="Size.Small" Min="0" Max="1" Step="0.05" Disabled="Generating">HP</MudSlider>           </MudItem>
+                        <MudItem xs="6" sm="4" md="2"><MudSlider @bind-Value="baseStatAttWeighting"   Size="Size.Small" Min="0" Max="1" Step="0.05" Disabled="Generating">Attack</MudSlider>       </MudItem>
+                        <MudItem xs="6" sm="4" md="2"><MudSlider @bind-Value="baseStatDefWeighting"   Size="Size.Small" Min="0" Max="1" Step="0.05" Disabled="Generating">Defense</MudSlider>      </MudItem>
+                        <MudItem xs="6" sm="4" md="2"><MudSlider @bind-Value="baseStatSpAttWeighting" Size="Size.Small" Min="0" Max="1" Step="0.05" Disabled="Generating">Sp. Attack</MudSlider>   </MudItem>
+                        <MudItem xs="6" sm="4" md="2"><MudSlider @bind-Value="baseStatSpDefWeighting" Size="Size.Small" Min="0" Max="1" Step="0.05" Disabled="Generating">Sp. Defense</MudSlider>  </MudItem>
+                        <MudItem xs="6" sm="4" md="2"><MudSlider @bind-Value="baseStatSpeWeighting"   Size="Size.Small" Min="0" Max="1" Step="0.05" Disabled="Generating">Speed</MudSlider>        </MudItem>
                     </MudGrid>
                 </MudItem>
             </MudGrid>

--- a/PokeAutobuilder/Shared/AutoBuilderDialog.razor
+++ b/PokeAutobuilder/Shared/AutoBuilderDialog.razor
@@ -120,7 +120,7 @@
             <MudText Typo="Typo.subtitle1">Use the checkboxes and sliders to adjust the importance of different team attributes.</MudText>
             <MudGrid Spacing="2">
                 <MudItem xs="12" md="6">
-                    <MudStack Class="px-1">
+                    <MudStack Class="px-2">
                         <MudTooltip Text="Prioritise a team with at least one Pokémon resistant to each type." Placement="Placement.Bottom" RootClass="mud-width-full">
                             <MudSlider @bind-Value="resistantAll" Size="Size.Medium" Min="0" Max="1" Step="0.05" Disabled="Generating">Resistant To All Types</MudSlider>
                         </MudTooltip>
@@ -136,7 +136,7 @@
                     </MudStack>
                 </MudItem>
                 <MudItem xs="12" md="6">
-                    <MudStack Class="px-1">
+                    <MudStack Class="px-2">
                         <MudTooltip Text="Determines how important a good balance of moves is." Placement="Placement.Bottom" RootClass="mud-width-full">
                             <MudSlider @bind-Value="moveSetBalanceWeighting" Size="Size.Medium" Min="0" Max="1" Step="0.05" Disabled="Generating">Balance Move Coverage</MudSlider>
                         </MudTooltip>

--- a/PokeAutobuilder/Shared/AutoBuilderDialog.razor
+++ b/PokeAutobuilder/Shared/AutoBuilderDialog.razor
@@ -14,6 +14,84 @@
         <MudStack AlignItems="AlignItems.Start">
             <MudDivider DividerType="DividerType.FullWidth" />
 
+            <MudGrid Class="mb-2">
+                <MudItem xs="12">
+                    <MudGrid Justify="Justify.SpaceEvenly">
+                        @for (int i = 0; i < PokemonTeam.MaxTeamSize; i++)
+                        {
+                            SmartPokemon? p = null;
+                            bool locked = false;
+                            if (LockedMembers is not null && LockedMembers.Pokemon[i] is not null)
+                            {
+                                p = LockedMembers.Pokemon[i];
+                                locked = true;
+                            }
+                            else
+                            {
+                                p = BestTeam.Pokemon[i];
+                            }
+
+                            @if (p is not null)
+                            {
+                                <MudItem xs="4" md="2">
+                                    <MudPaper>
+                                        @if (locked)
+                                        {
+                                            <MudIcon Class="ma-1" Icon="@Icons.Material.Filled.Lock" Color="Color.Primary" />
+                                        }
+                                        <PokemonCard Pokemon="p" />
+                                    </MudPaper>
+                                </MudItem>
+                            }
+                            else
+                            {
+                                <MudItem xs="4" md="2">
+                                    <MudSkeleton Height="100px"></MudSkeleton>
+                                </MudItem>
+                            }
+                        }
+                    </MudGrid>
+                </MudItem>
+                @if (!BestTeam.IsEmpty)
+                {
+                    <MudItem xs="12">
+                        <StatsTeamPanel Team="BestTeam" />
+                    </MudItem>
+                }
+            </MudGrid>
+
+            <MudGrid>
+                <MudItem xs="12" md="6">
+                    <MudStack Row="true">
+                        @if (Generating)
+                        {
+                            <MudButton Variant="Variant.Filled" StartIcon="@Icons.Material.Filled.Stop" Color="Color.Error" OnClick="OnClickStop">Stop</MudButton>
+                        }
+                        else
+                        {
+                            <MudButton Variant="Variant.Filled" StartIcon="@Icons.Material.Filled.PlayArrow" Color="Color.Success" OnClick="OnClickGenerate">Generate</MudButton>
+                        }
+                        <MudButton Disabled="Generating" Variant="Variant.Filled" Color="Color.Primary" OnClick="OnClickReset">Reset</MudButton>
+                    </MudStack>
+                </MudItem>
+                <MudItem xs="6" md="3">
+                    <MudNumericField Disabled="Generating" @bind-Value="NumGenerations" Label="Generations" Variant="Variant.Text" Min="10" Max="200" Step="10" />
+                </MudItem>
+                <MudItem xs="6" md="3">
+                    <MudNumericField Disabled="Generating" @bind-Value="PopulationSize" Label="Population Size" Variant="Variant.Text" Min="50" Max="1000" Step="50" />
+                </MudItem>
+                <MudItem xs="12" md="6">
+                    <MudButton Disabled="@(Generating || BestTeam.IsEmpty)" Variant="Variant.Filled" StartIcon="@Icons.Material.Filled.Upload" Color="Color.Primary" OnClick="OnClickLoadIntoEditor">Load Into Editor</MudButton>
+                </MudItem>
+            </MudGrid>
+
+            @if (Generating)
+            {
+                <MudProgressLinear Color="Color.Primary" Value="@ProgressValue" Size="Size.Medium" Max="@NumGenerations" />
+            }
+
+            <MudDivider DividerType="DividerType.FullWidth" />
+
             <MudText Typo="Typo.h6">Type Weightings</MudText>
             <MudText Typo="Typo.subtitle1">Click a type to toggle it. Disabled types won't be considered during team generation.</MudText>
             <div>
@@ -85,84 +163,6 @@
                 </MudItem>
             </MudGrid>
 
-            <MudGrid>
-                <MudItem xs="12" md="6">
-                    <MudStack Row="true">
-                    @if (Generating)
-                    {                    
-                        <MudButton Variant="Variant.Filled" StartIcon="@Icons.Material.Filled.Stop" Color="Color.Error" OnClick="OnClickStop">Stop</MudButton>
-                    }
-                    else
-                    {
-                        <MudButton Variant="Variant.Filled" StartIcon="@Icons.Material.Filled.PlayArrow" Color="Color.Success" OnClick="OnClickGenerate">Generate</MudButton>
-                    }
-                        <MudButton Disabled="Generating" Variant="Variant.Filled" Color="Color.Primary" OnClick="OnClickReset">Reset</MudButton>
-                    </MudStack>
-                </MudItem>
-                <MudItem xs="6" md="3">
-                    <MudNumericField Disabled="Generating" @bind-Value="NumGenerations" Label="Generations" Variant="Variant.Text" Min="10" Max="200" Step="10"/>
-                </MudItem>
-                <MudItem xs="6" md="3">
-                    <MudNumericField Disabled="Generating" @bind-Value="PopulationSize" Label="Population Size" Variant="Variant.Text" Min="50" Max="1000" Step="50" />
-                </MudItem>
-                <MudItem xs="12" md="6">
-                    <MudButton Disabled="@(Generating || BestTeam.IsEmpty)" Variant="Variant.Filled" StartIcon="@Icons.Material.Filled.Upload" Color="Color.Primary" OnClick="OnClickLoadIntoEditor">Load Into Editor</MudButton>
-                </MudItem>
-            </MudGrid>
-            @*</MudStack>*@
-
-            @if (Generating)
-            {
-                <MudProgressLinear Color="Color.Primary" Value="@ProgressValue" Size="Size.Medium" Max="@NumGenerations" />
-            }
-
-            <MudDivider DividerType="DividerType.FullWidth" />
-
-            <MudGrid>
-                <MudItem xs="12">
-                    <MudGrid Justify="Justify.SpaceEvenly">
-                        @for (int i = 0; i < PokemonTeam.MaxTeamSize; i++)
-                        {
-                            SmartPokemon? p = null;
-                            bool locked = false;
-                            if (LockedMembers is not null && LockedMembers.Pokemon[i] is not null)
-                            {
-                                p = LockedMembers.Pokemon[i];
-                                locked = true;
-                            }
-
-                            if (!locked)
-                                p = BestTeam.Pokemon[i];
-
-                            @if (p is not null)
-                            {
-                                <MudItem xs="4" md="2">
-                                    <MudPaper>
-                                        @if (locked)
-                                        {
-                                            <MudIcon Class="ma-1" Icon="@Icons.Material.Filled.Lock" Color="Color.Primary" />
-                                        }
-                                        <PokemonCard Pokemon="p" />
-                                    </MudPaper>
-                                </MudItem>
-                            }
-                            else
-                            {
-                                <MudItem xs="4" md="2">
-                                    <MudSkeleton Height="100px"></MudSkeleton>
-                                </MudItem>
-                            }
-                        }
-                    </MudGrid>
-                </MudItem>
-                @if (!BestTeam.IsEmpty)
-                {
-                    <MudItem xs="12" >
-                        <StatsTeamPanel Team="BestTeam" />
-                    </MudItem>
-                }
-            </MudGrid>
-
         </MudStack>
     </DialogContent>
     <DialogActions>
@@ -227,10 +227,7 @@
         // initialise type weightings list
         foreach (string t in Globals.AllTypes)
         {
-            if (t == "normal")
-                typeWeightings[t] = false;
-            else
-                typeWeightings[t] = true;
+            typeWeightings[t] = true;
         }
         base.OnParametersSet();
     }

--- a/PokeAutobuilder/Shared/WeightingSlider.razor
+++ b/PokeAutobuilder/Shared/WeightingSlider.razor
@@ -1,0 +1,49 @@
+﻿<MudTooltip Text="@Tooltip" Placement="Placement.Bottom" RootClass="mud-width-full">
+    <MudSlider @bind-Value="Value" Size="Size.Medium" Min="0" Max="1" Step="0.05" Disabled="Disabled">@Name</MudSlider>
+    @if (Score is not null)
+    {
+        <MudProgressLinear Color="Color.Tertiary" Size="Size.Medium" Value="@((double)Score)" Max="1.0">
+            <MudText Typo="Typo.caption">@(String.Format("{0:0.00}", Score * 100))%</MudText>
+        </MudProgressLinear>
+    }
+</MudTooltip>
+
+@code {
+    protected double? _value;
+
+    [Parameter]
+    public string? Name { get; set; }
+
+    [Parameter]
+    public string? Tooltip { get; set; }
+
+    [Parameter]
+    public double? Value
+    {
+        get => _value;
+        set
+        {
+            if (_value != value)
+            {
+                _value = value;
+                if (value is not null)
+                {
+                    ValueChanged.InvokeAsync((double)value);
+                }
+                else
+                {
+                    ValueChanged.InvokeAsync(0.0);
+                }
+            }
+        }
+    }
+
+    [Parameter]
+    public double? Score { get; set; }
+
+    [Parameter]
+    public bool Disabled { get; set; }
+
+    [Parameter]
+    public EventCallback<double> ValueChanged { get; set; }
+}


### PR DESCRIPTION
A selection of improvements to the autobuilder feature.
- New autobuilder parameters added for fine-tuning different team attributes. E.g. resistance balance and number of resistances are now separate parameters.
- Bars that display the score for each parameter have been added under each slider after a team has been generated. This should help users see how the algorithm has picked the team and how to adjust the sliders to get the result they want.
- Rearranged the entire dialog to put the generated team at the top and organise the sliders into meaningful groups.
- Closing and reopening the Autobuilder dialog will no longer reset all of the slider values.