### PR TITLE
Issue 42 - Edit the amount of team members

### DIFF
--- a/AutoBuilder/PokemonTeamChromosome.cs
+++ b/AutoBuilder/PokemonTeamChromosome.cs
@@ -33,7 +33,7 @@ namespace AutoBuilder
 
         public PokemonTeamChromosome(PokemonBox box, PokemonTeam lockedMembers)
         {
-            int length = PokemonTeam.MaxTeamSize;
+            int length = lockedMembers.Pokemon.Count;
             ValidateLength(length);
             m_length = length;
             m_genes = new Gene[length];
@@ -42,7 +42,7 @@ namespace AutoBuilder
 
             PokemonTeam randomTeam = _box.GetRandomTeam();
 
-            for (int i = 0; i < PokemonTeam.MaxTeamSize; i++)
+            for (int i = 0; i < length; i++)
             {
                 ReplaceGene(i, new Gene(randomTeam.Pokemon[i]));
             }
@@ -91,7 +91,7 @@ namespace AutoBuilder
         {
             var clone = new PokemonTeamChromosome(_box, _lockedMembers);
             var genes = GetGenes();
-            for (int i = 0; i < PokemonTeam.MaxTeamSize; i++)
+            for (int i = 0; i < m_length; i++)
             {
                 clone.ReplaceGene(i, new Gene((SmartPokemon?)genes[i].Value));
             }
@@ -105,17 +105,10 @@ namespace AutoBuilder
             var genes = GetGenes();
 
             PokemonTeam team = new();
-            for (int i = 0; i < PokemonTeam.MaxTeamSize; i++)
+            for (int i = 0; i < m_length; i++)
             {
                 SmartPokemon? pokemon = genes[i].Value as SmartPokemon;
-                if (pokemon?.Id == SmartPokemon.GetLockedPokemon().Id)
-                {
-                    team.Pokemon[i] = null;
-                }
-                else
-                {
-                    team.Pokemon[i] = pokemon;
-                }
+                team.Pokemon.Add(pokemon);
             }
 
             return team;

--- a/AutoBuilder/PokemonTeamChromosome.cs
+++ b/AutoBuilder/PokemonTeamChromosome.cs
@@ -104,15 +104,19 @@ namespace AutoBuilder
         {
             var genes = GetGenes();
 
-            // put into a new team then sort it
-            PokemonTeam team = new PokemonTeam();
+            PokemonTeam team = new();
             for (int i = 0; i < PokemonTeam.MaxTeamSize; i++)
             {
-                team.Pokemon[i] = genes[i].Value as SmartPokemon;
+                SmartPokemon? pokemon = genes[i].Value as SmartPokemon;
+                if (pokemon?.Id == SmartPokemon.GetLockedPokemon().Id)
+                {
+                    team.Pokemon[i] = null;
+                }
+                else
+                {
+                    team.Pokemon[i] = pokemon;
+                }
             }
-
-            // don't want to sort anymore because it messes up locked pokemon
-            //team.SortById();
 
             return team;
         }

--- a/AutoBuilder/PokemonTeamFitness.cs
+++ b/AutoBuilder/PokemonTeamFitness.cs
@@ -18,6 +18,15 @@ namespace AutoBuilder
                 return 0.0;
 
             PokemonTeam team = pokemonTeamChromosome.GetTeam();
+            
+            // set all "blank" slots to null
+            for (int i = 0; i < PokemonTeam.MaxTeamSize; i++)
+            {
+                if (team.Pokemon[i]?.Id == SmartPokemon.GetLockedPokemon().Id)
+                {
+                    team.Pokemon[i] = null;
+                }
+            }
 
             pokemonTeamChromosome.WeightingScores = AutoBuilder.CalculateScore(team, _weightings);
 

--- a/AutoBuilder/PokemonTeamFitness.cs
+++ b/AutoBuilder/PokemonTeamFitness.cs
@@ -18,15 +18,6 @@ namespace AutoBuilder
                 return 0.0;
 
             PokemonTeam team = pokemonTeamChromosome.GetTeam();
-            
-            // set all "blank" slots to null
-            for (int i = 0; i < PokemonTeam.MaxTeamSize; i++)
-            {
-                if (team.Pokemon[i]?.Id == SmartPokemon.GetLockedPokemon().Id)
-                {
-                    team.Pokemon[i] = null;
-                }
-            }
 
             pokemonTeamChromosome.WeightingScores = AutoBuilder.CalculateScore(team, _weightings);
 

--- a/AutoBuilderTests/AutoBuilderTests.cs
+++ b/AutoBuilderTests/AutoBuilderTests.cs
@@ -267,5 +267,76 @@ namespace PokeAutobuilderTests
             Assert.Contains(ferrothorn, bestTeam.Pokemon);
             Assert.Contains(gliscor, bestTeam.Pokemon);
         }
+
+        [Fact]
+        public async Task LockedGeneration()
+        {
+            PokemonBox box = new();
+            // add a selection of "bad" pokemon
+            SmartPokemon spearow = (await apiService!.GetPokemonAsync("spearow"))!; // used for lock test
+            box.Pokemon.Add(spearow);
+            box.Pokemon.Add((await apiService.GetPokemonAsync("rattata"))!);
+            box.Pokemon.Add((await apiService.GetPokemonAsync("wurmple"))!);
+            box.Pokemon.Add((await apiService.GetPokemonAsync("pidgey"))!);
+            box.Pokemon.Add((await apiService.GetPokemonAsync("zigzagoon"))!);
+            box.Pokemon.Add((await apiService.GetPokemonAsync("magikarp"))!);
+            box.Pokemon.Add((await apiService.GetPokemonAsync("whismur"))!);
+
+            // add 6 "good" pokemon that should theoretically get picked
+            SmartPokemon lapras = (await apiService.GetPokemonAsync("lapras"))!;
+            SmartPokemon gardevoir = (await apiService.GetPokemonAsync("gardevoir"))!;
+            SmartPokemon gengar = (await apiService.GetPokemonAsync("gengar"))!;
+            SmartPokemon talonflame = (await apiService.GetPokemonAsync("talonflame"))!;
+            SmartPokemon ferrothorn = (await apiService.GetPokemonAsync("ferrothorn"))!;
+            SmartPokemon gliscor = (await apiService.GetPokemonAsync("gliscor"))!;
+            box.Pokemon.Add(lapras);
+            box.Pokemon.Add(gardevoir);
+            box.Pokemon.Add(gengar);
+            box.Pokemon.Add(talonflame);
+            box.Pokemon.Add(ferrothorn);
+            box.Pokemon.Add(gliscor);
+
+            PokemonTeamGeneticAlgorithm GA = new();
+            AutoBuilderWeightings weightings = new();
+
+            PokemonTeam bestTeam = new();
+            double? bestScore = 0;
+            GA.GenerationRan += (g) =>
+            {
+                if (g.BestChromosome is null)
+                    return;
+
+                if (g.BestChromosome.Fitness > bestScore)
+                {
+                    bestScore = g.BestChromosome.Fitness;
+                    bestTeam = g.BestChromosome.GetTeam();
+                }
+
+                output.WriteLine("{0,-4}|{1,-9:0.000}|{2,-14:0.000}|{3,-30}"
+                    , g.GenerationsNumber
+                    , g.BestChromosome.Fitness
+                    , bestScore
+                    , bestTeam.ToString()
+                    );
+            };
+            output.WriteLine("Gen |G.Fitness|Best Fitness  |Best Team");
+
+            // lock some members of the team so they cannot change
+            PokemonTeam lockedMembers = new();
+            lockedMembers.Pokemon[0] = spearow;
+            lockedMembers.Pokemon[1] = SmartPokemon.GetLockedPokemon();
+            lockedMembers.Pokemon[4] = gliscor;
+
+            GA.Initialize(250, box, lockedMembers, weightings);
+            GA.Run(50);
+
+            // check that the final team has 6 unique members
+            Assert.False(bestTeam.ContainsDuplicates());
+
+            // check that the algorithm hasn't changed the locked members
+            Assert.True(bestTeam.Pokemon[0] == spearow);
+            Assert.True(bestTeam.Pokemon[1] is null);
+            Assert.True(bestTeam.Pokemon[4] == gliscor);
+        }
     }
 }

--- a/AutoBuilderTests/AutoBuilderTests.cs
+++ b/AutoBuilderTests/AutoBuilderTests.cs
@@ -195,7 +195,12 @@ namespace PokeAutobuilderTests
 
                 BestTeam = g.BestChromosome.GetTeam();
             };
-            GA.Initialize(50, box, new PokemonTeam(), weightings);
+            PokemonTeam lockedMembers = new();
+            for (int i = 0; i < PokemonTeam.MaxTeamSize; i++)
+            {
+                lockedMembers.Pokemon.Add(null);
+            }
+            GA.Initialize(50, box, lockedMembers, weightings);
             GA.Run(10);
 
             // check that the final team has 6 unique members
@@ -253,7 +258,12 @@ namespace PokeAutobuilderTests
                     );
             };
             output.WriteLine("Gen |G.Fitness|Best Fitness  |Best Team");
-            GA.Initialize(250, box, new PokemonTeam(), weightings);
+            PokemonTeam lockedMembers = new();
+            for (int i = 0; i < PokemonTeam.MaxTeamSize; i++)
+            {
+                lockedMembers.Pokemon.Add(null);
+            }
+            GA.Initialize(250, box, lockedMembers, weightings);
             GA.Run(50);
 
             // check that the final team has 6 unique members
@@ -323,20 +333,23 @@ namespace PokeAutobuilderTests
 
             // lock some members of the team so they cannot change
             PokemonTeam lockedMembers = new();
-            lockedMembers.Pokemon[0] = spearow;
-            lockedMembers.Pokemon[1] = SmartPokemon.GetLockedPokemon();
-            lockedMembers.Pokemon[4] = gliscor;
+            // 2 "modifiable" slots
+            for (int i = 0; i < 2; i++)
+            {
+                lockedMembers.Pokemon.Add(null);
+            }
+            lockedMembers.Pokemon.Add(spearow);
+            lockedMembers.Pokemon.Add(gliscor);
 
             GA.Initialize(250, box, lockedMembers, weightings);
             GA.Run(50);
 
-            // check that the final team has 6 unique members
+            // check that the final team has unique members
             Assert.False(bestTeam.ContainsDuplicates());
 
             // check that the algorithm hasn't changed the locked members
-            Assert.True(bestTeam.Pokemon[0] == spearow);
-            Assert.True(bestTeam.Pokemon[1] is null);
-            Assert.True(bestTeam.Pokemon[4] == gliscor);
+            Assert.True(bestTeam.Pokemon[2] == spearow);
+            Assert.True(bestTeam.Pokemon[3] == gliscor);
         }
     }
 }

--- a/PokeAutobuilder/Pages/TeamBuilderPage.razor
+++ b/PokeAutobuilder/Pages/TeamBuilderPage.razor
@@ -20,7 +20,7 @@
     <MudGrid Justify="Justify.FlexEnd">
         <MudItem xs="12" sm="6" Class="d-flex align-end justify-start mud-width-full">
             <MudSelect T="ILazyPokemonList" Label="Search Location" AnchorOrigin="Origin.TopCenter"
-                       @bind-Value="SearchLocation">
+            @bind-Value="SearchLocation">
                 @foreach (ILazyPokemonList list in SearchLocations!)
                 {
                     <MudSelectItem T="ILazyPokemonList" Value="list">
@@ -40,7 +40,7 @@
             <MudItem xs="6" sm="4" lg="2">
                 <PokemonSearchBox @ref="tempCard" SearchFunc="SearchAsync" OnPokemonChanged="PokemonSearchBoxUpdatedAsync" Lockable="true">
                     <ExtraButtons>
-@*                         <MudTooltip Text="Randomize">
+                        @*                         <MudTooltip Text="Randomize">
                             <MudIconButton Disabled="Locked" Size="Size.Small" Icon="@Icons.Material.Filled.Loop" OnClick="OnClickRandomize"></MudIconButton>
                         </MudTooltip> *@
                     </ExtraButtons>
@@ -118,7 +118,12 @@
         for (int i = 0; i < PokemonTeam.MaxTeamSize; i++)
         {
             if (cards[i]!.Locked)
-                lockedMembers.Pokemon[i] = cards[i]!.Pokemon;
+            {
+                if (cards[i]!.Pokemon is not null)
+                    lockedMembers.Pokemon[i] = cards[i]!.Pokemon;
+                else
+                    lockedMembers.Pokemon[i] = SmartPokemon.GetLockedPokemon();
+            }
         }
         return lockedMembers;
     }

--- a/PokeAutobuilder/Pages/TeamBuilderPage.razor
+++ b/PokeAutobuilder/Pages/TeamBuilderPage.razor
@@ -38,7 +38,7 @@
         @for (int i = 0; i < PokemonTeam.MaxTeamSize; i++)
         {
             <MudItem xs="6" sm="4" lg="2">
-                <PokemonSearchBox @ref="tempCard" SearchFunc="SearchAsync" OnPokemonChanged="PokemonSearchBoxUpdatedAsync" Lockable="true">
+                <PokemonSearchBox @ref="tempCard" SearchFunc="SearchAsync" OnPokemonChanged="PokemonSearchBoxUpdatedAsync" OnLockChanged="StateHasChanged" Lockable="true">
                     <ExtraButtons>
                         @*                         <MudTooltip Text="Randomize">
                             <MudIconButton Disabled="Locked" Size="Size.Small" Icon="@Icons.Material.Filled.Loop" OnClick="OnClickRandomize"></MudIconButton>
@@ -48,7 +48,7 @@
             </MudItem>
         }
     </MudGrid>
-    @if (Profile.PokemonStorage.Boxes[0].Pokemon.Count < 7 || GetLockedMembers().CountPokemon() >= PokemonTeam.MaxTeamSize - 1)
+    @if (!CanRunAutoBuilder())
     {
         <MudTooltip Text="@GetAutoBuilderTooltipMessage()">
             <MudButton Disabled="true" OnClick="OnClickAutoBuilder" Color="Color.Primary" StartIcon="@Icons.Material.Filled.SmartToy" Size="Size.Large" Variant="Variant.Filled" Style="max-width: 500px;">Auto Builder</MudButton>
@@ -96,7 +96,7 @@
     List<PokemonSearchBox> cards = [];
     PokemonSearchBox tempCard
     {
-        set { cards.Add(value); }
+        set { cards.Add(value); StateHasChanged(); }
     }  
 
     public async void OnClickAddTeamToStorage()
@@ -107,33 +107,12 @@
         Snackbar.Add("Added team '" + Session.Team.Name + "' to Team Storage", Severity.Success);
     }
 
-    public PokemonTeam GetLockedMembers()
-    {
-        // build a team containing the locked members
-        PokemonTeam lockedMembers = new PokemonTeam();
-
-        if (cards.Count == 0)
-            return lockedMembers;
-
-        for (int i = 0; i < PokemonTeam.MaxTeamSize; i++)
-        {
-            if (cards[i]!.Locked)
-            {
-                if (cards[i]!.Pokemon is not null)
-                    lockedMembers.Pokemon[i] = cards[i]!.Pokemon;
-                else
-                    lockedMembers.Pokemon[i] = SmartPokemon.GetLockedPokemon();
-            }
-        }
-        return lockedMembers;
-    }
-
     public string GetAutoBuilderTooltipMessage()
     {
-        if (Profile.PokemonStorage.Boxes[0].Pokemon.Count < 7)
-            return "Please fill Pokémon storage with at least 7 Pokémon before using the Auto Builder";
+        if (Profile.PokemonStorage.Boxes[0].Pokemon.Count < cards.Count(c => !c.Locked || (c.Locked && c.Pokemon is not null)) + 1)
+            return "Please add more Pokémon to storage in order to use the Auto Builder";
 
-        if (GetLockedMembers().CountPokemon() >= PokemonTeam.MaxTeamSize - 1)
+        if (cards.Count(c => !c.Locked) < 2)
             return "Please unlock some more Pokémon before using the Auto Builder";
 
         return "";
@@ -142,7 +121,19 @@
     public async Task OnClickAutoBuilder()
     {
         var parameters = new DialogParameters();
-        parameters.Add("LockedMembers", GetLockedMembers());
+        List<Tuple<SmartPokemon?, int>> inputTeam = [];
+        for (int i = 0; i < PokemonTeam.MaxTeamSize; i++)
+        {
+            if (!cards[i].Locked)
+            {
+                inputTeam.Add(new Tuple<SmartPokemon?, int>(null, i));
+            }
+            else if (cards[i].Pokemon is not null)
+            {
+                inputTeam.Add(new Tuple<SmartPokemon?, int>(cards[i].Pokemon, i));
+            }
+        }
+        parameters.Add("InputTeam", inputTeam);
 
 
         var dialog = await DialogService.ShowAsync<AutoBuilderDialog>("Automatic Team Builder", parameters);
@@ -160,9 +151,14 @@
         bool anyPokemonChanged = false;
         for (int i = 0; i < PokemonTeam.MaxTeamSize; i++)
         {
-            if (cards[i].Pokemon != Session.Team.Pokemon[i])
+            SmartPokemon? selectedPokemon = null;
+            if (Session.Team.Pokemon.Count > i)
             {
-                cards[i].Pokemon = Session.Team.Pokemon[i];
+                selectedPokemon = Session.Team.Pokemon[i];
+            }
+            if (cards[i].Pokemon != selectedPokemon)
+            {
+                cards[i].Pokemon = selectedPokemon;
                 anyPokemonChanged = true;
             }
         }
@@ -196,6 +192,12 @@
                 await Session.SetTeamPokemonAsync(teamIndex, card.Pokemon);
             }
         }
+    }
+
+    protected bool CanRunAutoBuilder()
+    {
+        return Profile.PokemonStorage.Boxes[0].Pokemon.Count >= cards.Count(c => !c.Locked || (c.Locked && c.Pokemon is not null)) + 1
+        && cards.Count(c => !c.Locked) >= 2;
     }
 
     protected override void OnInitialized()

--- a/PokeAutobuilder/Shared/AutoBuilderDialog.razor
+++ b/PokeAutobuilder/Shared/AutoBuilderDialog.razor
@@ -17,13 +17,13 @@
             <MudGrid Class="mb-2">
                 <MudItem xs="12">
                     <MudGrid Justify="Justify.SpaceEvenly">
-                        @for (int i = 0; i < PokemonTeam.MaxTeamSize; i++)
+                        @for (int i = 0; i < InputTeam!.Count; i++)
                         {
                             SmartPokemon? p = null;
                             bool locked = false;
-                            if (LockedMembers is not null && LockedMembers.Pokemon[i] is not null)
+                            if (InputTeam![i].Item1 is not null)
                             {
-                                p = LockedMembers.Pokemon[i];
+                                p = InputTeam![i].Item1;
                                 locked = true;
                             }
                             else
@@ -301,7 +301,7 @@
     MudDialogInstance? MudDialog { get; set; }
 
     [Parameter]
-    public PokemonTeam? LockedMembers { get; set; }
+    public List<Tuple<SmartPokemon?, int>>? InputTeam { get; set; }
 
     private PokemonTeamGeneticAlgorithm GeneticAlgorithm = new PokemonTeamGeneticAlgorithm();
     private PokemonTeam BestTeam = new PokemonTeam();
@@ -363,6 +363,15 @@
         }
     }
 
+    protected override Task OnParametersSetAsync()
+    {
+        foreach ( var(pokemon, teamIdx) in InputTeam!)
+        {
+            BestTeam.Pokemon.Add(pokemon);
+        }
+        return base.OnParametersSetAsync();
+    }
+
     public void OnClickType(string typeName)
     {
         GenerationParameters.Types[typeName] = !GenerationParameters.Types[typeName];
@@ -378,10 +387,16 @@
 
         AutoBuilderWeightings weightingsCopy = new(GenerationParameters);
 
+        PokemonTeam lockedMembers = new();
+        foreach (var (pokemon, teamIdx) in InputTeam!)
+        {
+            lockedMembers.Pokemon.Add(pokemon);
+        }
+
         GeneticAlgorithm.Initialize(
             PopulationSize
             , Profile.PokemonStorage.Boxes[0]
-            , LockedMembers is null ? new PokemonTeam() : LockedMembers
+            , lockedMembers
             , weightingsCopy);
         GeneticAlgorithm.RunInBackground();
 
@@ -405,7 +420,22 @@
 
     public async Task OnClickLoadIntoEditor()
     {
-        await Session.SetTeamAsync(BestTeam);
+        PokemonTeam outputTeam = new();
+        int bestTeamIdx = 0;
+        for (int i = 0; i < PokemonTeam.MaxTeamSize; i++)
+        {
+            int teamIdx = InputTeam!.FindIndex(t => t.Item2 == i);
+            if (teamIdx != -1)
+            {
+                outputTeam.Pokemon.Add(BestTeam.Pokemon[bestTeamIdx]);
+                bestTeamIdx++;
+            }
+            else
+            {
+                outputTeam.Pokemon.Add(null);
+            }
+        }
+        await Session.SetTeamAsync(outputTeam);
         await Session.SetAutobuilderParamsAsync(GenerationParameters);
         MudDialog!.Close(DialogResult.Ok(true));
     }

--- a/PokeAutobuilder/Shared/PageFooter.razor
+++ b/PokeAutobuilder/Shared/PageFooter.razor
@@ -1,7 +1,7 @@
 ﻿<MudDivider DividerType="DividerType.FullWidth" Class="mt-4" />
 <MudStack AlignItems="AlignItems.Center" Spacing="0">
-	<MudText Typo="Typo.caption">©2023–2024 <MudLink Href="https://github.com/Swepps">swepps</MudLink>.</MudText>
-	<MudText Typo="Typo.caption">©1995–2024 Pokémon characters and names are copyright © The Pokémon Company and/or Nintendo.</MudText>
+	<MudText Typo="Typo.caption">©2023–@DateTime.Now.Year <MudLink Href="https://github.com/Swepps">swepps</MudLink>.</MudText>
+	<MudText Typo="Typo.caption">©1995–@DateTime.Now.Year Pokémon characters and names are copyright © The Pokémon Company and/or Nintendo.</MudText>
 </MudStack>
 
 @code {

--- a/PokeAutobuilder/Shared/PokemonSearchBox.razor
+++ b/PokeAutobuilder/Shared/PokemonSearchBox.razor
@@ -15,12 +15,14 @@
 
 <MudPaper Elevation="4" Class="d-flex flex-column align-center justify-center mud-width-full pa-2">
 
+    <div style="width: 100%;">
     @if (Lockable)
     {
         <MudToggleIconButton @bind-Toggled="@Locked"
             Icon="@Icons.Material.Filled.LockOpen" Color="@Color.Dark"
-            ToggledIcon="@Icons.Material.Filled.Lock" ToggledColor="@Color.Primary" />
+            ToggledIcon="@Icons.Material.Filled.Lock" ToggledColor="@Color.Primary" Style="padding: 0;"/>
     }
+    </div>
 
     <MudAutocomplete T="IPokemonSearchable" Label="Pokémon" @bind-Value="PokemonSearchValue" SearchFunc="@(SearchFunc!)"
     ResetValueOnEmptyText="true" Disabled="@_locked" MaxItems="50"

--- a/PokeAutobuilder/Shared/PokemonSearchBox.razor
+++ b/PokeAutobuilder/Shared/PokemonSearchBox.razor
@@ -36,7 +36,8 @@
     </MudAutocomplete>
 
     <div style="height: 50px">
-        @if (_pokemonSearchValueVarieties.Count > 1)
+        @if (_pokemonSearchValueVarieties.Count > 1
+            && !_locked)
         {
             <MudSelect Dense="true" T="string" Label="Form" AnchorOrigin="Origin.TopCenter"
             @bind-Value="_PokemonFormName">
@@ -86,6 +87,9 @@
 
     [Parameter]
     public EventCallback<PokemonSearchBox> OnPokemonChanged { get; set; }
+
+    [Parameter]
+    public EventCallback<bool> OnLockChanged { get; set; }
 
     [Parameter]
     public bool Lockable { get; set; } = false;
@@ -140,8 +144,10 @@
         set
         {
             _locked = value;
+            _ = OnLockChanged.InvokeAsync(_locked);
         }
     }
+    private bool _prevLocked = false;
 
     private bool _errorFetchingPokemon = false;
 
@@ -271,10 +277,11 @@
 
     protected override bool ShouldRender()
     {
-        return _prevPokemon != _pokemon ||
-        _prevPokemonSearchValue != _pokemonSearchValue ||
-        _prevPokemonFormName != _pokemonFormName ||
-        _pokemonSearchValueVarietiesChanged;
+        return _prevPokemon != _pokemon 
+        || _prevPokemonSearchValue != _pokemonSearchValue
+        || _prevPokemonFormName != _pokemonFormName
+        || _prevLocked != _locked
+        || _pokemonSearchValueVarietiesChanged;
     }
 
     protected override void OnAfterRender(bool firstRender)
@@ -282,6 +289,7 @@
         _prevPokemon = _pokemon;
         _prevPokemonSearchValue = _pokemonSearchValue;
         _prevPokemonFormName = _pokemonFormName;
+        _prevLocked = _locked;
         _pokemonSearchValueVarietiesChanged = false;
     }
 }

--- a/PokeAutobuilder/Shared/PokemonSearchBox.razor
+++ b/PokeAutobuilder/Shared/PokemonSearchBox.razor
@@ -15,24 +15,31 @@
 
 <MudPaper Elevation="4" Class="d-flex flex-column align-center justify-center mud-width-full pa-2">
 
-        <MudAutocomplete T="IPokemonSearchable" Label="Pokémon" @bind-Value="PokemonSearchValue" SearchFunc="@(SearchFunc!)"
-                         ResetValueOnEmptyText="true" Disabled="Locked" MaxItems="50"
-                         CoerceText="true" CoerceValue="false" ShowProgressIndicator="true">
-            <MoreItemsTemplate>
-                <MudText Align="Align.Center" Typo="Typo.body1">
-                    ...                    
-                </MudText>
-                <MudText Align="Align.Center" Typo="Typo.body2">
+    @if (Lockable)
+    {
+        <MudToggleIconButton @bind-Toggled="@Locked"
+            Icon="@Icons.Material.Filled.LockOpen" Color="@Color.Dark"
+            ToggledIcon="@Icons.Material.Filled.Lock" ToggledColor="@Color.Primary" />
+    }
+
+    <MudAutocomplete T="IPokemonSearchable" Label="Pokémon" @bind-Value="PokemonSearchValue" SearchFunc="@(SearchFunc!)"
+    ResetValueOnEmptyText="true" Disabled="@_locked" MaxItems="50"
+    CoerceText="true" CoerceValue="false" ShowProgressIndicator="true">
+        <MoreItemsTemplate>
+            <MudText Align="Align.Center" Typo="Typo.body1">
+                ...                    
+            </MudText>
+            <MudText Align="Align.Center" Typo="Typo.body2">
                 50 results shown. Start typing to look for more.
             </MudText>
-            </MoreItemsTemplate>
-        </MudAutocomplete>
+        </MoreItemsTemplate>
+    </MudAutocomplete>
 
     <div style="height: 50px">
         @if (_pokemonSearchValueVarieties.Count > 1)
         {
             <MudSelect Dense="true" T="string" Label="Form" AnchorOrigin="Origin.TopCenter"
-                       @bind-Value="_PokemonFormName">
+            @bind-Value="_PokemonFormName">
                 @foreach (var v in _pokemonSearchValueVarieties)
                 {
                     <MudSelectItem Value="@v.Name" />
@@ -43,19 +50,13 @@
     @if (Pokemon is not null)
     {
         <PokemonCard Pokemon="Pokemon" IsNameDisplayed="false" />
-        @if (Lockable)
-        {
-            <MudToggleIconButton @bind-Toggled="@Locked"
-                                 Icon="@Icons.Material.Filled.LockOpen" Color="@Color.Dark"
-                                 ToggledIcon="@Icons.Material.Filled.Lock" ToggledColor="@Color.Primary" />
-        }
         <MudButtonGroup Color="Color.Primary" Variant="Variant.Outlined">
             <MudTooltip Text="Details">
                 <MudIconButton Size="Size.Small" Icon="@Icons.Material.Filled.OpenInFull" OnClick="OnClickDetails"></MudIconButton>
             </MudTooltip>
             <MudTooltip Text="Add To Storage">
                 <MudIconButton Disabled="@(Profile.PokemonStorage.Boxes[0].Pokemon.Contains(Pokemon))"
-                               Size="Size.Small" Icon="@Icons.Material.Filled.Save" OnClick="OnClickAddToStorage"></MudIconButton>
+                Size="Size.Small" Icon="@Icons.Material.Filled.Save" OnClick="OnClickAddToStorage"></MudIconButton>
             </MudTooltip>
             @ExtraButtons
         </MudButtonGroup>

--- a/PokeAutobuilder/Source/Services/SessionService.cs
+++ b/PokeAutobuilder/Source/Services/SessionService.cs
@@ -1,4 +1,5 @@
-﻿using Accord.IO;
+﻿using Accord;
+using Accord.IO;
 using AutoBuilder;
 using Blazored.SessionStorage;
 using PokeApiNet;
@@ -20,6 +21,7 @@ namespace PokeAutobuilder.Source.Services
         private static readonly string AUTOBUILDER_PARAMS = "autobuilder_params";
         private static readonly string SEARCH_LOCATION = "search_location";
 
+        // the session team should always contain 6 members
         private PokemonTeam _pokemonTeam = new(); 
         public PokemonTeam Team 
         {
@@ -69,6 +71,14 @@ namespace PokeAutobuilder.Source.Services
                 );
 
             _pokemonTeam = taskPokemonTeam.Result ?? new();
+            if (_pokemonTeam.Pokemon.Count == 0)
+            {
+                // initialize with an empty team of 6
+                for (int i = 0; i < PokemonTeam.MaxTeamSize; i++)
+                {
+                    _pokemonTeam.Pokemon.Add(null);
+                }
+            }
             _autobuilderParams = taskAutobuilderParams.Result ?? null;
             _searchLocation = taskSearchLocation.Result ?? "National Pokédex";
         }
@@ -81,6 +91,14 @@ namespace PokeAutobuilder.Source.Services
         public async Task SetTeamAsync(PokemonTeam team)
         {
             _pokemonTeam = team;
+            // ensure the team has the correct number of Pokemon
+            if (_pokemonTeam.Pokemon.Count < PokemonTeam.MaxTeamSize)
+            {
+                for (int i = _pokemonTeam.Pokemon.Count; i < PokemonTeam.MaxTeamSize; i++)
+                {
+                    _pokemonTeam.Pokemon.Add(null);
+                }
+            }
             OnTeamChange?.Invoke();
             await _sessionStorageService.SetItemAsync(POKEMON_TEAM_KEY, team);
         }

--- a/PokemonDataModel/Pokemon.cs
+++ b/PokemonDataModel/Pokemon.cs
@@ -148,6 +148,25 @@ namespace PokemonDataModel
             UpdateMultipliers();
 		}
 
+        // Returns a pokemon with no stats or type information
+        // This is useful for having "empty" slots in the team
+        public static SmartPokemon GetLockedPokemon()
+        {
+            return new SmartPokemon(-1, "locked", null, 0, true, 0, 0, [], [], []
+            , [], "", [], [], new PokemonSprites(), new NamedApiResource<PokemonSpecies>()
+
+            // stats
+            , [   new PokemonStat { Stat = new NamedApiResource<Stat> { Name = "hp" }, BaseStat = 0 } 
+                , new PokemonStat { Stat = new NamedApiResource<Stat> { Name = "attack" }, BaseStat = 0 }
+                , new PokemonStat { Stat = new NamedApiResource<Stat> { Name = "special-attack" }, BaseStat = 0 }
+                , new PokemonStat { Stat = new NamedApiResource<Stat> { Name = "defense" }, BaseStat = 0 }
+                , new PokemonStat { Stat = new NamedApiResource<Stat> { Name = "special-defense" }, BaseStat = 0 }
+                , new PokemonStat { Stat = new NamedApiResource<Stat> { Name = "speed" }, BaseStat = 0 }
+                ]
+
+                , [], new PokemonAbility { Ability = new NamedApiResource<Ability>() }, new PokemonMoveset(), [], [], [], []);
+        }
+
         public async Task<PokemonSpecies> GetSpeciesAsync()
         {
             if (_loadedSpecies is null)

--- a/PokemonDataModel/PokemonStorage.cs
+++ b/PokemonDataModel/PokemonStorage.cs
@@ -61,7 +61,8 @@ namespace PokemonDataModel
             {
                 lockedMembers = new PokemonTeam();
             }
-            else if (lockedMembers.CountPokemon() >= PokemonTeam.MaxTeamSize || Pokemon.Count < PokemonTeam.MaxTeamSize)
+            else if (!lockedMembers.Pokemon.Any(p => p == null) 
+                || Pokemon.Count < PokemonTeam.MaxTeamSize)
             {
                 // they're all locked!
                 return lockedMembers;
@@ -77,13 +78,14 @@ namespace PokemonDataModel
             int randIdx = 0;
             for (int i = 0; i < PokemonTeam.MaxTeamSize; i++)
             {
-                if (lockedMembers.Pokemon[i] != null)
+                if (lockedMembers.Pokemon.Count > i
+                    && lockedMembers.Pokemon[i] != null)
                 {
-                    newTeam.Pokemon[i] = lockedMembers.Pokemon[i];
+                    newTeam.Pokemon.Add(lockedMembers.Pokemon[i]);
                 }
                 else if (randIdx < randomMembers.Count)
                 {
-                    newTeam.Pokemon[i] = randomMembers[randIdx];
+                    newTeam.Pokemon.Add(randomMembers[randIdx]);
                     randIdx++;
                 }
             }

--- a/PokemonDataModel/PokemonTeam.cs
+++ b/PokemonDataModel/PokemonTeam.cs
@@ -8,7 +8,7 @@ namespace PokemonDataModel
         public static readonly int MaxTeamSize = 6;
 
         [JsonPropertyName("pokemon")]
-        public List<SmartPokemon?> Pokemon { get; set; } = new();
+        public List<SmartPokemon?> Pokemon { get; set; } = [];
 
         [JsonPropertyName("team_name")]
         private string name = "";
@@ -58,18 +58,12 @@ namespace PokemonDataModel
 
         public PokemonTeam() 
         {
-            // fill team with 6 null pokemon
-            for (int i = 0; i < MaxTeamSize; i++)
-            {
-                Pokemon.Add(null);
-            }
         }
 
         // copy constructor
 		public PokemonTeam(PokemonTeam team)
 		{
-			// fill team with 6 null pokemon
-			for (int i = 0; i < MaxTeamSize; i++)
+			for (int i = 0; i < team.Pokemon.Count; i++)
 			{
                 Pokemon.Add(team.Pokemon[i]);
 			}
@@ -79,16 +73,18 @@ namespace PokemonDataModel
 
 		public bool ContainsDuplicates()
         {
-            return Pokemon.Distinct().Count() != Pokemon.Count;
+            return Pokemon
+                .Where(p => p != null)
+                .Distinct()
+                .Count() != Pokemon.Count(p => p != null);
         }
 
         public int CountPokemon()
         {
             int count = 0;
-            for (int i = 0; i < MaxTeamSize; i++)
+            for (int i = 0; i < Pokemon.Count; i++)
             {
-                SmartPokemon? p = Pokemon[i];
-                if (p != null) count++;
+                if (Pokemon[i] != null) count++;
             }
             return count;
         }
@@ -97,7 +93,7 @@ namespace PokemonDataModel
         public int CountWeaknesses(string typeName)
         {
             int weaknesses = 0;
-            for (int i = 0; i < MaxTeamSize; i++)
+            for (int i = 0; i < Pokemon.Count; i++)
             {
                 SmartPokemon? p = Pokemon[i];
                 if (p == null) continue;
@@ -116,7 +112,7 @@ namespace PokemonDataModel
         public int CountResistances(string typeName)
         {
             int resistances = 0;
-            for (int i = 0; i < MaxTeamSize; i++)
+            for (int i = 0; i < Pokemon.Count; i++)
             {
                 SmartPokemon? p = Pokemon[i];
                 if (p == null) continue;
@@ -135,7 +131,7 @@ namespace PokemonDataModel
         public int CountSTABCoverage(string typeName)
         {
             int coverage = 0;
-            for (int i = 0; i < MaxTeamSize; i++)
+            for (int i = 0; i < Pokemon.Count; i++)
             {
                 SmartPokemon? p = Pokemon[i];
                 if (p == null) continue;
@@ -152,7 +148,7 @@ namespace PokemonDataModel
 		public int CountMoveCoverage(string typeName)
 		{
 			int coverage = 0;
-			for (int i = 0; i < MaxTeamSize; i++)
+			for (int i = 0; i < Pokemon.Count; i++)
 			{
 				SmartPokemon? p = Pokemon[i];
 				if (p == null) continue;
@@ -173,7 +169,7 @@ namespace PokemonDataModel
 
             // now empty this team and refill with sorted list
             Pokemon.Clear();
-            for (int i = 0; i < MaxTeamSize; ++i)
+            for (int i = 0; i < Pokemon.Count; ++i)
             {
                 if (i < team.Count)
                     Pokemon.Add(team[i]);


### PR DESCRIPTION
Empty slots can now be locked on the team builder pager. This allows a user to "adjust" the size of a team by locking an empty slot.

The auto builder should still work but on a reduced number of team members.