### PR TITLE
A variety of storage page improvements (and other small things)

### DIFF
--- a/PokeAutobuilder/Pages/PokemonStoragePage.razor
+++ b/PokeAutobuilder/Pages/PokemonStoragePage.razor
@@ -206,7 +206,7 @@
         Profile.OnStorageChange += StateHasChanged;
         if (SearchLocations is not null)
         {
-            _searchLocation = SearchLocations.FirstOrDefault();
+            _searchLocation = SearchLocations.FirstOrDefault((ILazyPokemonList list) => !Profile.PokemonStorage.Boxes.Contains(list));
         }
 
         if (Profile.PokemonStorage.Boxes.Count > 0)
@@ -234,20 +234,28 @@
         StateHasChanged();
     }
 
-    protected Task OnClickAddBox()
+    protected void OnClickAddBox()
     {
         Profile.PokemonStorage.Boxes.Add(new($"Box {Profile.PokemonStorage.Boxes.Count + 1}"));
         _ = Profile.UpdatePokemonStorageAsync();
+        if (SearchLocations is not null)
+        {
+            SearchLocations.Insert(Profile.PokemonStorage.Boxes.Count - 1, Profile.PokemonStorage.Boxes.Last());
+        }
         SelectedBoxNumber = Profile.PokemonStorage.Boxes.Count;
         SelectedPokemon = null;
         _storagePanel = StoragePanel.Add;
     }
 
-    protected Task OnClickDeleteBox()
+    protected void OnClickDeleteBox()
     {
         if (SelectedBoxNumber > 0 
             && SelectedBoxNumber <= Profile.PokemonStorage.Boxes.Count)
         {
+            if (SearchLocations is not null)
+            {
+                SearchLocations.Remove(Profile.PokemonStorage.Boxes.ElementAt(SelectedBoxNumber - 1));
+            }
             Profile.PokemonStorage.Boxes.RemoveAt(SelectedBoxNumber - 1);
             _ = Profile.UpdatePokemonStorageAsync();
             SelectedBoxNumber = Math.Clamp(SelectedBoxNumber, 1, Profile.PokemonStorage.Boxes.Count);
@@ -258,7 +266,7 @@
 
     protected async Task OnClickDownloadBoxAsync()
     {
-        await JS.InvokeVoidAsync("localStorageHelper.exportBoxToFile", "pokemon_storage", 0, $"pokeautobuilderbox-{Profile.PokemonStorage.Boxes[0].Name}.json");
+        await JS.InvokeVoidAsync("localStorageHelper.exportBoxToFile", "pokemon_storage", SelectedBoxNumber - 1, $"pokeautobuilderbox-{SelectedBox.Name}.json");
     }
 
     protected async Task OnClickUploadBoxAsync()
@@ -275,6 +283,8 @@
         await Profile.LoadPokemonStorageAsync();
         // select the last box in the list as it will be the one that was just imported
         SelectedBoxNumber = Profile.PokemonStorage.Boxes.Count;
+        SelectedPokemon = null;
+        _storagePanel = StoragePanel.Add;
         StateHasChanged();
     }
 

--- a/PokeAutobuilder/Pages/PokemonStoragePage.razor
+++ b/PokeAutobuilder/Pages/PokemonStoragePage.razor
@@ -32,21 +32,13 @@
             <MudIconButton OnClick="@OnClickUploadBoxAsync" Icon="@Icons.Material.Filled.Upload" title="Upload a Pokémon box" />
         </MudButtonGroup>
 
-        <MudIconButton OnClick="@OnClickPreviousBox" 
-            Disabled="@(SelectedBox == Profile.PokemonStorage.Boxes.First())" 
-            Variant="Variant.Outlined" 
-            Icon="@Icons.Material.Filled.ArrowLeft" title="Previous Box" />
+        <MudPagination ShowPageButtons="false" Count="@Profile.PokemonStorage.Boxes.Count" @bind-Selected="SelectedBoxNumber" />
 
         <MudTextField @bind-Value="SelectedBox.Name" 
             Label="Box Name" 
             Variant="Variant.Outlined" 
             Class="px-1"
             FullWidth="false"/>
-
-        <MudIconButton OnClick="@OnClickNextBox" 
-            Disabled="@(SelectedBox == Profile.PokemonStorage.Boxes.Last())" 
-            Variant="Variant.Outlined" 
-            Icon="@Icons.Material.Filled.ArrowRight" title="Next Box" />
     </MudToolBar>
 </MudPaper>
 <div class="d-flex flex-wrap">
@@ -143,6 +135,17 @@
 
     private bool _selectedPokemonCanEvolve = false;
 
+    private int _selectedBoxNumber = 1;
+    public int SelectedBoxNumber
+    {
+        get => _selectedBoxNumber;
+        set
+        {
+            _selectedBoxNumber = value;
+            SelectedBox = Profile.PokemonStorage.Boxes[_selectedBoxNumber - 1];
+        }
+    }
+
     private PokemonBox _selectedBox = new();
     public PokemonBox SelectedBox
     {
@@ -205,28 +208,6 @@
 
         await JS.InvokeVoidAsync("HTMLElement.prototype.click.call",
             _filePicker.Element);
-    }
-
-    protected Task OnClickNextBox()
-    {
-        int indexOfCurrent = Profile.PokemonStorage.Boxes.IndexOf(SelectedBox);
-        if (indexOfCurrent >= 0 && indexOfCurrent < Profile.PokemonStorage.Boxes.Count - 1)
-        {
-            SelectedBox = Profile.PokemonStorage.Boxes[indexOfCurrent + 1];            
-        }
-
-        return Task.CompletedTask;
-    }
-
-    protected Task OnClickPreviousBox()
-    {
-        int indexOfCurrent = Profile.PokemonStorage.Boxes.IndexOf(SelectedBox);
-        if (indexOfCurrent > 0 && indexOfCurrent < Profile.PokemonStorage.Boxes.Count)
-        {
-            SelectedBox = Profile.PokemonStorage.Boxes[indexOfCurrent - 1];
-        }
-
-        return Task.CompletedTask;
     }
 
     private async Task HandleFileSelectedAsync(InputFileChangeEventArgs e)

--- a/PokeAutobuilder/Pages/PokemonStoragePage.razor
+++ b/PokeAutobuilder/Pages/PokemonStoragePage.razor
@@ -19,17 +19,25 @@
 <MudPaper Elevation="25" Square="true">
     <MudToolBar>
         <MudToggleGroup T="StoragePanel" @bind-Value="_storagePanel">
-            <MudToggleItem Value="StoragePanel.Add">
-                <MudIcon Icon="@Icons.Material.Outlined.Add" Title="Open the Pokémon browser"/>
-            </MudToggleItem>
-            <MudToggleItem Value="StoragePanel.Edit" Disabled="@(_selectedPokemon == null)">
-                <MudIcon Icon="@Icons.Material.Outlined.Edit" Title="Edit the currently selected Pokémon"/>
-            </MudToggleItem>
+            <MudTooltip Text="Open the Pokémon browser">
+                <MudToggleItem Value="StoragePanel.Add">
+                    <MudIcon Icon="@Icons.Material.Outlined.Add" />
+                </MudToggleItem>
+            </MudTooltip>
+            <MudTooltip Text="Edit the currently selected Pokémon">
+                <MudToggleItem Value="StoragePanel.Edit" Disabled="@(_selectedPokemon == null)">
+                    <MudIcon Icon="@Icons.Material.Outlined.Edit" />
+                </MudToggleItem>
+            </MudTooltip>
         </MudToggleGroup>
 
         <MudButtonGroup Variant="Variant.Outlined" Class="px-2" Color="Color.Primary">
-            <MudIconButton OnClick="@OnClickDownloadBoxAsync" Icon="@Icons.Material.Filled.Download" title="Download this Pokémon box" />
-            <MudIconButton OnClick="@OnClickUploadBoxAsync" Icon="@Icons.Material.Filled.Upload" title="Upload a Pokémon box" />
+            <MudTooltip Text="Download this Pokémon box">
+                <MudIconButton OnClick="@OnClickDownloadBoxAsync" Icon="@Icons.Material.Filled.Download" />
+            </MudTooltip>
+            <MudTooltip Text="Upload a Pokémon box">
+                <MudIconButton OnClick="@OnClickUploadBoxAsync" Icon="@Icons.Material.Filled.Upload" />
+            </MudTooltip>
         </MudButtonGroup>
 
         <MudPagination ShowPageButtons="false" Count="@Profile.PokemonStorage.Boxes.Count" @bind-Selected="SelectedBoxNumber" />
@@ -47,26 +55,29 @@
         {
             case StoragePanel.Add: 
                 <MudStack Class="pa-2" Style="max-width: 250px;">
-                    <MudText Typo="Typo.caption" Color="Color.Info">
-                        Use the controls below to find Pokémon to add to storage
-                    </MudText>
                     <MudSelect T="ILazyPokemonList" Label="Search Location" AnchorOrigin="Origin.BottomCenter" TransformOrigin="Origin.TopCenter" FullWidth="false"
                     @bind-Value="_searchLocation">
                         @foreach (ILazyPokemonList list in SearchLocations!)
                         {
-                            <MudSelectItem T="ILazyPokemonList" Value="list">
-                                @list.Name
-                            </MudSelectItem>
+                            @if (!Profile.PokemonStorage.Boxes.Contains(list))
+                            {
+                                <MudSelectItem T="ILazyPokemonList" Value="list">
+                                    @list.Name
+                                </MudSelectItem>
+                            }
                         }
                     </MudSelect>
                     <div style="max-width: 250px;">
                         <PokemonSearchBox @ref="_pokemonSearchBox" SearchFunc="SearchAsync">
                             <ExtraButtons>
 
-                                <MudTooltip Text="Add To Storage">
-                                    <MudIconButton Disabled="@(SelectedBox.Pokemon.Contains(_pokemonSearchBox!.Pokemon!))"
-                                                   Size="Size.Small" Icon="@Icons.Material.Filled.Save" OnClick="OnClickAddToStorageAsync"></MudIconButton>
-                                </MudTooltip>
+                                @if (_pokemonSearchBox!.Pokemon is not null)
+                                {
+                                    <MudTooltip Text="Add To Storage">
+                                        <MudIconButton Disabled="@(SelectedBox.Pokemon.Contains(_pokemonSearchBox!.Pokemon!))"
+                                        Size="Size.Small" Icon="@Icons.Material.Filled.Save" OnClick="OnClickAddToStorageAsync"></MudIconButton>
+                                    </MudTooltip>
+                                }
 
                                 <MudTooltip Text="Randomize">
                                     <MudIconButton Size="Size.Small" Icon="@Icons.Material.Filled.Loop" OnClick="OnClickRandomizeAsync"></MudIconButton>

--- a/PokeAutobuilder/Pages/PokemonStoragePage.razor
+++ b/PokeAutobuilder/Pages/PokemonStoragePage.razor
@@ -60,7 +60,7 @@
     </MudToolBar>
 </MudPaper>
 <div class="d-flex flex-wrap">
-    <MudPaper MaxWidth="600px" Height="fit-content" Square="true">
+    <MudPaper MaxWidth="650px" Height="fit-content" Square="true">
         @switch (_storagePanel)
         {
             case StoragePanel.Add: 

--- a/PokeAutobuilder/Pages/PokemonStoragePage.razor
+++ b/PokeAutobuilder/Pages/PokemonStoragePage.razor
@@ -8,21 +8,28 @@
 @inject NavigationManager NavigationManager
 @inject ProfileService Profile
 @inject IDialogService DialogService
+@inject IJSRuntime JS
 
 @implements IDisposable
 
 <PageTitle>Pokémon Storage</PageTitle>
 
+<InputFile id="filePicker" @ref="_filePicker" OnChange="HandleFileSelected" style="display: none;"/>
+
 <MudPaper Elevation="25" Square="true">
     <MudToolBar>
         <MudToggleGroup T="StoragePanel" @bind-Value="_storagePanel">
             <MudToggleItem Value="StoragePanel.Add">
-                <MudIcon Icon="@Icons.Material.Outlined.Add" />
+                <MudIcon Icon="@Icons.Material.Outlined.Add" Title="Open the Pokémon browser"/>
             </MudToggleItem>
             <MudToggleItem Value="StoragePanel.Edit" Disabled="@(_selectedPokemon == null)">
-                <MudIcon Icon="@Icons.Material.Outlined.Edit" />
+                <MudIcon Icon="@Icons.Material.Outlined.Edit" Title="Edit the currently selected Pokémon"/>
             </MudToggleItem>
         </MudToggleGroup>
+        <MudButtonGroup Variant="Variant.Outlined">
+            <MudIconButton OnClick="@OnClickDownloadBox" Icon="@Icons.Material.Filled.Download" title="Download this Pokémon box" />
+            <MudIconButton OnClick="@OnClickUploadBox" Icon="@Icons.Material.Filled.Upload" title="Upload a Pokémon box" />
+        </MudButtonGroup>
     </MudToolBar>
 </MudPaper>
 <div class="d-flex flex-wrap">
@@ -122,6 +129,8 @@
     protected enum StoragePanel { Edit, Add }
     protected StoragePanel _storagePanel = StoragePanel.Add;
 
+    private InputFile? _filePicker;
+
     private string _messageBoxState = "Message box hasn't been opened yet";
 
     protected override void OnInitialized()
@@ -146,6 +155,24 @@
         SelectedPokemon = selectedPokemon;
         _storagePanel = StoragePanel.Edit;
         StateHasChanged();
+    }
+
+    protected async Task OnClickDownloadBox()
+    {
+        await JS.InvokeVoidAsync("localStorageHelper.exportBoxToFile", "pokemon_storage", 0, $"pokeautobuilderbox-{Profile.PokemonStorage.Boxes[0].Name}.json");
+    }
+
+    protected async Task OnClickUploadBox()
+    {
+        if (_filePicker is null) return;
+
+        await JS.InvokeVoidAsync("HTMLElement.prototype.click.call",
+            _filePicker.Element);
+    }
+
+    private async Task HandleFileSelected(InputFileChangeEventArgs e)
+    {
+        await JS.InvokeVoidAsync("localStorageHelper.importBoxFromFile", "pokemon_storage", "filePicker", DotNetObjectReference.Create(this));
     }
 
     protected async Task OnClickReleaseAsync()

--- a/PokeAutobuilder/Pages/PokemonStoragePage.razor
+++ b/PokeAutobuilder/Pages/PokemonStoragePage.razor
@@ -233,7 +233,6 @@
 
     protected async Task OnSelectPokemonAsync(SmartPokemon selectedPokemon)
     {
-        SelectedPokemon = null;
         _selectedPokemonCanEvolve = await PokeApiService.Instance!.CanEvolve(selectedPokemon);
         SelectedPokemon = selectedPokemon;
         _storagePanel = StoragePanel.Edit;

--- a/PokeAutobuilder/Pages/PokemonStoragePage.razor
+++ b/PokeAutobuilder/Pages/PokemonStoragePage.razor
@@ -38,7 +38,7 @@
                 <MudIconButton OnClick="@OnClickAddBox" Icon="@Icons.Material.Filled.Add" />
             </MudTooltip>
             <MudTooltip Text="Delete this Pokémon box">
-                <MudIconButton OnClick="@OnClickDeleteBox" Icon="@Icons.Material.Filled.Delete" Disabled="@(Profile.PokemonStorage.Boxes.Count <= 1)" />
+                <MudIconButton OnClick="@OnClickDeleteBoxAsync" Icon="@Icons.Material.Filled.Delete" Disabled="@(Profile.PokemonStorage.Boxes.Count <= 1)" />
             </MudTooltip>
             <MudTooltip Text="Download this Pokémon box">
                 <MudIconButton OnClick="@OnClickDownloadBoxAsync" Icon="@Icons.Material.Filled.Download" />
@@ -247,20 +247,30 @@
         _storagePanel = StoragePanel.Add;
     }
 
-    protected void OnClickDeleteBox()
+    protected async Task OnClickDeleteBoxAsync()
     {
         if (SelectedBoxNumber > 0 
             && SelectedBoxNumber <= Profile.PokemonStorage.Boxes.Count)
         {
-            if (SearchLocations is not null)
+            bool? result = await DialogService.ShowMessageBox(
+                "Warning"
+                , $"Are you sure you want to delete box: {SelectedBox.Name}?"
+                , yesText: "Delete!"
+                , cancelText: "Cancel"
+                , options: new() { MaxWidth = MaxWidth.ExtraSmall }
+            );
+            if (result is not null)
             {
-                SearchLocations.Remove(Profile.PokemonStorage.Boxes.ElementAt(SelectedBoxNumber - 1));
+                if (SearchLocations is not null)
+                {
+                    SearchLocations.Remove(Profile.PokemonStorage.Boxes.ElementAt(SelectedBoxNumber - 1));
+                }
+                Profile.PokemonStorage.Boxes.RemoveAt(SelectedBoxNumber - 1);
+                _ = Profile.UpdatePokemonStorageAsync();
+                SelectedBoxNumber = Math.Clamp(SelectedBoxNumber, 1, Profile.PokemonStorage.Boxes.Count);
+                SelectedPokemon = null;
+                _storagePanel = StoragePanel.Add;
             }
-            Profile.PokemonStorage.Boxes.RemoveAt(SelectedBoxNumber - 1);
-            _ = Profile.UpdatePokemonStorageAsync();
-            SelectedBoxNumber = Math.Clamp(SelectedBoxNumber, 1, Profile.PokemonStorage.Boxes.Count);
-            SelectedPokemon = null;
-            _storagePanel = StoragePanel.Add;
         }
     }
 
@@ -275,6 +285,12 @@
 
         await JS.InvokeVoidAsync("HTMLElement.prototype.click.call",
             _filePicker.Element);
+    }
+
+    [JSInvokable]
+    public static bool ValidateBoxJson(string json)
+    {
+        return JsonValidator.TryValidatePokemonBoxJson(json, out _);
     }
 
     [JSInvokable]

--- a/PokeAutobuilder/Pages/PokemonStoragePage.razor
+++ b/PokeAutobuilder/Pages/PokemonStoragePage.razor
@@ -17,50 +17,8 @@
 
 <InputFile id="filePicker" @ref="_filePicker" accept=".json" OnChange="HandleFileSelectedAsync" style="display: none;"/>
 
-<MudPaper Elevation="25" Square="true">
-    <MudToolBar WrapContent="true">
-        <MudToggleGroup T="StoragePanel" @bind-Value="_storagePanel" Class="my-4">
-            <MudTooltip Text="Open the Pokémon browser">
-                <MudToggleItem Value="StoragePanel.Add">
-                    <MudIcon Icon="@Icons.Material.Outlined.Search" />
-                </MudToggleItem>
-            </MudTooltip>
-            <MudTooltip Text="Edit the currently selected Pokémon">
-                <MudToggleItem Value="StoragePanel.Edit" Disabled="@(_selectedPokemon == null)">
-                    <MudIcon Icon="@Icons.Material.Outlined.Edit" />
-                </MudToggleItem>
-            </MudTooltip>
-        </MudToggleGroup>
-
-        <MudDivider Vertical="true" DividerType="DividerType.FullWidth"/>
-
-        <MudButtonGroup Variant="Variant.Outlined" Class="mx-2 my-4" Color="Color.Primary">
-            <MudTooltip Text="Add a new Pokémon box">
-                <MudIconButton OnClick="@OnClickAddBox" Icon="@Icons.Material.Filled.Add" />
-            </MudTooltip>
-            <MudTooltip Text="Delete this Pokémon box">
-                <MudIconButton OnClick="@OnClickDeleteBoxAsync" Icon="@Icons.Material.Filled.Delete" Disabled="@(Profile.PokemonStorage.Boxes.Count <= 1)" />
-            </MudTooltip>
-            <MudTooltip Text="Download this Pokémon box">
-                <MudIconButton OnClick="@OnClickDownloadBoxAsync" Icon="@Icons.Material.Filled.Download" />
-            </MudTooltip>
-            <MudTooltip Text="Upload a Pokémon box">
-                <MudIconButton OnClick="@OnClickUploadBoxAsync" Icon="@Icons.Material.Filled.Upload" />
-            </MudTooltip>
-        </MudButtonGroup>        
-
-        <MudStack Row="true" class="flex-grow-1">
-            <MudTextField @bind-Value="_boxName" 
-                Label="Box Name" 
-                Variant="Variant.Outlined" 
-                FullWidth="false"/>
-
-            <MudPagination Count="@Profile.PokemonStorage.Boxes.Count" @bind-Selected="SelectedBoxNumber" BoundaryCount="2"/>
-        </MudStack>
-    </MudToolBar>
-</MudPaper>
 <div class="d-flex flex-wrap">
-    <MudPaper MaxWidth="650px" Height="fit-content" Square="true">
+    <MudPaper MaxWidth="650px" Height="fit-content">
         @switch (_storagePanel)
         {
             case StoragePanel.Add: 
@@ -134,11 +92,58 @@
                 break;
         }
     </MudPaper>
-    <MudPaper Class="pa-1 d-flex flex-1" MinWidth="325px" Elevation="0" Square="true">
-        <CascadingValue Value="@SelectedPokemon">
-            <PokemonStorageBox PokemonCollection="SelectedBox!.Pokemon" OnClickPokemon="OnSelectPokemonAsync" />
-        </CascadingValue>
-    </MudPaper>
+
+    <div class="ma-1 d-flex flex-1" style="min-width: 500px;">
+        <MudStack Spacing="0" AlignItems="AlignItems.Center">
+            <MudPaper Outlined="true" Width="fit-content">
+                <MudToolBar WrapContent="true">
+                    <MudToggleGroup T="StoragePanel" @bind-Value="_storagePanel" Class="my-4">
+                        <MudTooltip Text="Open the Pokémon browser">
+                            <MudToggleItem Value="StoragePanel.Add">
+                                <MudIcon Icon="@Icons.Material.Outlined.Search" />
+                            </MudToggleItem>
+                        </MudTooltip>
+                        <MudTooltip Text="Edit the currently selected Pokémon">
+                            <MudToggleItem Value="StoragePanel.Edit" Disabled="@(_selectedPokemon == null)">
+                                <MudIcon Icon="@Icons.Material.Outlined.Edit" />
+                            </MudToggleItem>
+                        </MudTooltip>
+                    </MudToggleGroup>
+
+                    <MudDivider Vertical="true" DividerType="DividerType.FullWidth" />
+
+                    <MudButtonGroup Variant="Variant.Outlined" Class="ml-2 my-4 mr-4" Color="Color.Primary">
+                        <MudTooltip Text="Add a new Pokémon box">
+                            <MudIconButton OnClick="@OnClickAddBox" Icon="@Icons.Material.Filled.Add" />
+                        </MudTooltip>
+                        <MudTooltip Text="Delete this Pokémon box">
+                            <MudIconButton OnClick="@OnClickDeleteBoxAsync" Icon="@Icons.Material.Filled.Delete" Disabled="@(Profile.PokemonStorage.Boxes.Count <= 1)" />
+                        </MudTooltip>
+                        <MudTooltip Text="Download this Pokémon box">
+                            <MudIconButton OnClick="@OnClickDownloadBoxAsync" Icon="@Icons.Material.Filled.Download" />
+                        </MudTooltip>
+                        <MudTooltip Text="Upload a Pokémon box">
+                            <MudIconButton OnClick="@OnClickUploadBoxAsync" Icon="@Icons.Material.Filled.Upload" />
+                        </MudTooltip>
+                    </MudButtonGroup>
+
+                    <MudStack Row="true" class="flex-grow-1 my-1">
+                        <MudTextField @bind-Value="_boxName"
+                                      Label="Box Name"
+                                      Variant="Variant.Outlined"
+                                      FullWidth="false" 
+                                      Margin="Margin.Dense"/>
+
+                        <MudPagination Count="@Profile.PokemonStorage.Boxes.Count" @bind-Selected="SelectedBoxNumber" BoundaryCount="2" />
+                    </MudStack>
+                </MudToolBar>
+            </MudPaper>
+            <CascadingValue Value="@SelectedPokemon">
+                <PokemonStorageBox PokemonCollection="SelectedBox!.Pokemon" OnClickPokemon="OnSelectPokemonAsync" />
+            </CascadingValue>
+        </MudStack>
+    </div>
+
 </div>
 
 <PageFooter />

--- a/PokeAutobuilder/Pages/PokemonStoragePage.razor
+++ b/PokeAutobuilder/Pages/PokemonStoragePage.razor
@@ -14,7 +14,7 @@
 
 <PageTitle>Pokémon Storage</PageTitle>
 
-<InputFile id="filePicker" @ref="_filePicker" OnChange="HandleFileSelected" style="display: none;"/>
+<InputFile id="filePicker" @ref="_filePicker" OnChange="HandleFileSelectedAsync" style="display: none;"/>
 
 <MudPaper Elevation="25" Square="true">
     <MudToolBar>
@@ -26,10 +26,27 @@
                 <MudIcon Icon="@Icons.Material.Outlined.Edit" Title="Edit the currently selected Pokémon"/>
             </MudToggleItem>
         </MudToggleGroup>
-        <MudButtonGroup Variant="Variant.Outlined">
-            <MudIconButton OnClick="@OnClickDownloadBox" Icon="@Icons.Material.Filled.Download" title="Download this Pokémon box" />
-            <MudIconButton OnClick="@OnClickUploadBox" Icon="@Icons.Material.Filled.Upload" title="Upload a Pokémon box" />
+
+        <MudButtonGroup Variant="Variant.Outlined" Class="px-2" Color="Color.Primary">
+            <MudIconButton OnClick="@OnClickDownloadBoxAsync" Icon="@Icons.Material.Filled.Download" title="Download this Pokémon box" />
+            <MudIconButton OnClick="@OnClickUploadBoxAsync" Icon="@Icons.Material.Filled.Upload" title="Upload a Pokémon box" />
         </MudButtonGroup>
+
+        <MudIconButton OnClick="@OnClickPreviousBox" 
+            Disabled="@(SelectedBox == Profile.PokemonStorage.Boxes.First())" 
+            Variant="Variant.Outlined" 
+            Icon="@Icons.Material.Filled.ArrowLeft" title="Previous Box" />
+
+        <MudTextField @bind-Value="SelectedBox.Name" 
+            Label="Box Name" 
+            Variant="Variant.Outlined" 
+            Class="px-1"
+            FullWidth="false"/>
+
+        <MudIconButton OnClick="@OnClickNextBox" 
+            Disabled="@(SelectedBox == Profile.PokemonStorage.Boxes.Last())" 
+            Variant="Variant.Outlined" 
+            Icon="@Icons.Material.Filled.ArrowRight" title="Next Box" />
     </MudToolBar>
 </MudPaper>
 <div class="d-flex flex-wrap">
@@ -99,7 +116,7 @@
     </MudPaper>
     <MudPaper Class="pa-1 d-flex flex-1" MinWidth="325px" Elevation="0" Square="true">
         <CascadingValue Value="@SelectedPokemon">
-            <PokemonStorageBox PokemonCollection="Profile.PokemonStorage.Boxes[0].Pokemon" OnClickPokemon="OnSelectPokemonAsync" />
+            <PokemonStorageBox PokemonCollection="SelectedBox!.Pokemon" OnClickPokemon="OnSelectPokemonAsync" />
         </CascadingValue>
     </MudPaper>
 </div>
@@ -126,6 +143,16 @@
 
     private bool _selectedPokemonCanEvolve = false;
 
+    private PokemonBox _selectedBox = new();
+    public PokemonBox SelectedBox
+    {
+        get => _selectedBox;
+        set
+        {
+            _selectedBox = value;
+        }
+    }
+
     protected enum StoragePanel { Edit, Add }
     protected StoragePanel _storagePanel = StoragePanel.Add;
 
@@ -140,6 +167,16 @@
         if (SearchLocations is not null)
         {
             _searchLocation = SearchLocations.FirstOrDefault();
+        }
+
+        if (Profile.PokemonStorage.Boxes.Count > 0)
+        {
+            SelectedBox = Profile.PokemonStorage.Boxes[0];
+        }
+        else
+        {
+            Profile.PokemonStorage.Boxes.Add(SelectedBox);
+            _ = Profile.UpdatePokemonStorageAsync();
         }
     }
 
@@ -157,12 +194,12 @@
         StateHasChanged();
     }
 
-    protected async Task OnClickDownloadBox()
+    protected async Task OnClickDownloadBoxAsync()
     {
         await JS.InvokeVoidAsync("localStorageHelper.exportBoxToFile", "pokemon_storage", 0, $"pokeautobuilderbox-{Profile.PokemonStorage.Boxes[0].Name}.json");
     }
 
-    protected async Task OnClickUploadBox()
+    protected async Task OnClickUploadBoxAsync()
     {
         if (_filePicker is null) return;
 
@@ -170,7 +207,29 @@
             _filePicker.Element);
     }
 
-    private async Task HandleFileSelected(InputFileChangeEventArgs e)
+    protected Task OnClickNextBox()
+    {
+        int indexOfCurrent = Profile.PokemonStorage.Boxes.IndexOf(SelectedBox);
+        if (indexOfCurrent >= 0 && indexOfCurrent < Profile.PokemonStorage.Boxes.Count - 1)
+        {
+            SelectedBox = Profile.PokemonStorage.Boxes[indexOfCurrent + 1];            
+        }
+
+        return Task.CompletedTask;
+    }
+
+    protected Task OnClickPreviousBox()
+    {
+        int indexOfCurrent = Profile.PokemonStorage.Boxes.IndexOf(SelectedBox);
+        if (indexOfCurrent > 0 && indexOfCurrent < Profile.PokemonStorage.Boxes.Count)
+        {
+            SelectedBox = Profile.PokemonStorage.Boxes[indexOfCurrent - 1];
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private async Task HandleFileSelectedAsync(InputFileChangeEventArgs e)
     {
         await JS.InvokeVoidAsync("localStorageHelper.importBoxFromFile", "pokemon_storage", "filePicker", DotNetObjectReference.Create(this));
     }

--- a/PokeAutobuilder/Pages/PokemonStoragePage.razor
+++ b/PokeAutobuilder/Pages/PokemonStoragePage.razor
@@ -9,12 +9,13 @@
 @inject ProfileService Profile
 @inject IDialogService DialogService
 @inject IJSRuntime JS
+@inject ISnackbar Snackbar
 
 @implements IDisposable
 
 <PageTitle>Pokémon Storage</PageTitle>
 
-<InputFile id="filePicker" @ref="_filePicker" OnChange="HandleFileSelectedAsync" style="display: none;"/>
+<InputFile id="filePicker" @ref="_filePicker" accept=".json" OnChange="HandleFileSelectedAsync" style="display: none;"/>
 
 <MudPaper Elevation="25" Square="true">
     <MudToolBar WrapContent="true">
@@ -288,9 +289,9 @@
     }
 
     [JSInvokable]
-    public static bool ValidateBoxJson(string json)
+    public Task<bool> ValidateBoxJson(string json)
     {
-        return JsonValidator.TryValidatePokemonBoxJson(json, out _);
+        return Task.FromResult(JsonValidator.TryValidatePokemonBoxJson(json, out _));
     }
 
     [JSInvokable]
@@ -305,8 +306,9 @@
     }
 
     [JSInvokable]
-    public Task OnUploadBoxFailure()
+    public Task OnUploadBoxFailure(string errorString)
     {
+        Snackbar.Add($"Failed to upload box. Error: \n{errorString}", Severity.Error);
         StateHasChanged();
         return Task.CompletedTask;
     }

--- a/PokeAutobuilder/Pages/PokemonStoragePage.razor
+++ b/PokeAutobuilder/Pages/PokemonStoragePage.razor
@@ -17,11 +17,11 @@
 <InputFile id="filePicker" @ref="_filePicker" OnChange="HandleFileSelectedAsync" style="display: none;"/>
 
 <MudPaper Elevation="25" Square="true">
-    <MudToolBar>
-        <MudToggleGroup T="StoragePanel" @bind-Value="_storagePanel">
+    <MudToolBar WrapContent="true">
+        <MudToggleGroup T="StoragePanel" @bind-Value="_storagePanel" Class="my-4">
             <MudTooltip Text="Open the Pokémon browser">
                 <MudToggleItem Value="StoragePanel.Add">
-                    <MudIcon Icon="@Icons.Material.Outlined.Add" />
+                    <MudIcon Icon="@Icons.Material.Outlined.Search" />
                 </MudToggleItem>
             </MudTooltip>
             <MudTooltip Text="Edit the currently selected Pokémon">
@@ -31,22 +31,31 @@
             </MudTooltip>
         </MudToggleGroup>
 
-        <MudButtonGroup Variant="Variant.Outlined" Class="px-2" Color="Color.Primary">
+        <MudDivider Vertical="true" DividerType="DividerType.FullWidth"/>
+
+        <MudButtonGroup Variant="Variant.Outlined" Class="mx-2 my-4" Color="Color.Primary">
+            <MudTooltip Text="Add a new Pokémon box">
+                <MudIconButton OnClick="@OnClickAddBoxAsync" Icon="@Icons.Material.Filled.Add" />
+            </MudTooltip>
+            <MudTooltip Text="Delete this Pokémon box">
+                <MudIconButton OnClick="@OnClickDeleteBoxAsync" Icon="@Icons.Material.Filled.Delete" Disabled="@(Profile.PokemonStorage.Boxes.Count <= 1)" />
+            </MudTooltip>
             <MudTooltip Text="Download this Pokémon box">
                 <MudIconButton OnClick="@OnClickDownloadBoxAsync" Icon="@Icons.Material.Filled.Download" />
             </MudTooltip>
             <MudTooltip Text="Upload a Pokémon box">
                 <MudIconButton OnClick="@OnClickUploadBoxAsync" Icon="@Icons.Material.Filled.Upload" />
             </MudTooltip>
-        </MudButtonGroup>
+        </MudButtonGroup>        
 
-        <MudPagination ShowPageButtons="false" Count="@Profile.PokemonStorage.Boxes.Count" @bind-Selected="SelectedBoxNumber" />
+        <MudStack Row="true" class="flex-grow-1">
+            <MudTextField @bind-Value="_boxName" 
+                Label="Box Name" 
+                Variant="Variant.Outlined" 
+                FullWidth="false"/>
 
-        <MudTextField @bind-Value="_boxName" 
-            Label="Box Name" 
-            Variant="Variant.Outlined" 
-            Class="px-1"
-            FullWidth="false"/>
+            <MudPagination Count="@Profile.PokemonStorage.Boxes.Count" @bind-Selected="SelectedBoxNumber" BoundaryCount="2"/>
+        </MudStack>
     </MudToolBar>
 </MudPaper>
 <div class="d-flex flex-wrap">
@@ -223,6 +232,28 @@
         SelectedPokemon = selectedPokemon;
         _storagePanel = StoragePanel.Edit;
         StateHasChanged();
+    }
+
+    protected async Task OnClickAddBoxAsync()
+    {
+        Profile.PokemonStorage.Boxes.Add(new($"Box {Profile.PokemonStorage.Boxes.Count + 1}"));
+        _ = Profile.UpdatePokemonStorageAsync();
+        SelectedBoxNumber = Profile.PokemonStorage.Boxes.Count;
+        SelectedPokemon = null;
+        _storagePanel = StoragePanel.Add;
+    }
+
+    protected async Task OnClickDeleteBoxAsync()
+    {
+        if (SelectedBoxNumber > 0 
+            && SelectedBoxNumber <= Profile.PokemonStorage.Boxes.Count)
+        {
+            Profile.PokemonStorage.Boxes.RemoveAt(SelectedBoxNumber - 1);
+            _ = Profile.UpdatePokemonStorageAsync();
+            SelectedBoxNumber = Math.Clamp(SelectedBoxNumber, 1, Profile.PokemonStorage.Boxes.Count);
+            SelectedPokemon = null;
+            _storagePanel = StoragePanel.Add;
+        }
     }
 
     protected async Task OnClickDownloadBoxAsync()

--- a/PokeAutobuilder/Pages/PokemonStoragePage.razor
+++ b/PokeAutobuilder/Pages/PokemonStoragePage.razor
@@ -35,10 +35,10 @@
 
         <MudButtonGroup Variant="Variant.Outlined" Class="mx-2 my-4" Color="Color.Primary">
             <MudTooltip Text="Add a new Pokémon box">
-                <MudIconButton OnClick="@OnClickAddBoxAsync" Icon="@Icons.Material.Filled.Add" />
+                <MudIconButton OnClick="@OnClickAddBox" Icon="@Icons.Material.Filled.Add" />
             </MudTooltip>
             <MudTooltip Text="Delete this Pokémon box">
-                <MudIconButton OnClick="@OnClickDeleteBoxAsync" Icon="@Icons.Material.Filled.Delete" Disabled="@(Profile.PokemonStorage.Boxes.Count <= 1)" />
+                <MudIconButton OnClick="@OnClickDeleteBox" Icon="@Icons.Material.Filled.Delete" Disabled="@(Profile.PokemonStorage.Boxes.Count <= 1)" />
             </MudTooltip>
             <MudTooltip Text="Download this Pokémon box">
                 <MudIconButton OnClick="@OnClickDownloadBoxAsync" Icon="@Icons.Material.Filled.Download" />
@@ -234,7 +234,7 @@
         StateHasChanged();
     }
 
-    protected async Task OnClickAddBoxAsync()
+    protected Task OnClickAddBox()
     {
         Profile.PokemonStorage.Boxes.Add(new($"Box {Profile.PokemonStorage.Boxes.Count + 1}"));
         _ = Profile.UpdatePokemonStorageAsync();
@@ -243,7 +243,7 @@
         _storagePanel = StoragePanel.Add;
     }
 
-    protected async Task OnClickDeleteBoxAsync()
+    protected Task OnClickDeleteBox()
     {
         if (SelectedBoxNumber > 0 
             && SelectedBoxNumber <= Profile.PokemonStorage.Boxes.Count)

--- a/PokeAutobuilder/Pages/PokemonStoragePage.razor
+++ b/PokeAutobuilder/Pages/PokemonStoragePage.razor
@@ -34,7 +34,7 @@
 
         <MudPagination ShowPageButtons="false" Count="@Profile.PokemonStorage.Boxes.Count" @bind-Selected="SelectedBoxNumber" />
 
-        <MudTextField @bind-Value="SelectedBox.Name" 
+        <MudTextField @bind-Value="_boxName" 
             Label="Box Name" 
             Variant="Variant.Outlined" 
             Class="px-1"
@@ -62,9 +62,16 @@
                     <div style="max-width: 250px;">
                         <PokemonSearchBox @ref="_pokemonSearchBox" SearchFunc="SearchAsync">
                             <ExtraButtons>
+
+                                <MudTooltip Text="Add To Storage">
+                                    <MudIconButton Disabled="@(SelectedBox.Pokemon.Contains(_pokemonSearchBox!.Pokemon!))"
+                                                   Size="Size.Small" Icon="@Icons.Material.Filled.Save" OnClick="OnClickAddToStorageAsync"></MudIconButton>
+                                </MudTooltip>
+
                                 <MudTooltip Text="Randomize">
                                     <MudIconButton Size="Size.Small" Icon="@Icons.Material.Filled.Loop" OnClick="OnClickRandomizeAsync"></MudIconButton>
                                 </MudTooltip>
+
                             </ExtraButtons>
                         </PokemonSearchBox>
                     </div>
@@ -156,6 +163,16 @@
         }
     }
 
+    private string _boxName
+    {
+        get => SelectedBox.Name;
+        set
+        {
+            SelectedBox.Name = value;
+            _ = Profile.UpdatePokemonStorageAsync();
+        }
+    }
+
     protected enum StoragePanel { Edit, Add }
     protected StoragePanel _storagePanel = StoragePanel.Add;
 
@@ -208,6 +225,22 @@
 
         await JS.InvokeVoidAsync("HTMLElement.prototype.click.call",
             _filePicker.Element);
+    }
+
+    [JSInvokable]
+    public async Task OnUploadBoxSuccessAsync()
+    {
+        await Profile.LoadPokemonStorageAsync();
+        // select the last box in the list as it will be the one that was just imported
+        SelectedBoxNumber = Profile.PokemonStorage.Boxes.Count;
+        StateHasChanged();
+    }
+
+    [JSInvokable]
+    public Task OnUploadBoxFailure()
+    {
+        StateHasChanged();
+        return Task.CompletedTask;
     }
 
     private async Task HandleFileSelectedAsync(InputFileChangeEventArgs e)
@@ -263,16 +296,18 @@
         }
     }
 
+    protected async Task OnClickAddToStorageAsync()
+    {
+        await Profile.AddPokemonToStorageAsync(_pokemonSearchBox!.Pokemon!, SelectedBoxNumber - 1);
+    }
+
     protected async Task OnClickRandomizeAsync()
     {
-        if (_pokemonSearchBox is not null && _searchLocation is not null)
-        {
-            _pokemonSearchBox.PokemonSearchValue = null;
-            IEnumerable<IPokemonSearchable> list = await _searchLocation.GetListAsync();
-            Random rand = new Random();
-            int index = rand.Next(0, list.Count());
-            _pokemonSearchBox.PokemonSearchValue = list.ElementAt(index);
-        }
+        _pokemonSearchBox!.PokemonSearchValue = null;
+        IEnumerable<IPokemonSearchable> list = await _searchLocation!.GetListAsync();
+        Random rand = new Random();
+        int index = rand.Next(0, list.Count());
+        _pokemonSearchBox.PokemonSearchValue = list.ElementAt(index);
     }
 
     protected void OnPokemonMoveChanged((SmartPokemon, int, PokemonMove?) args)

--- a/PokeAutobuilder/Pages/PokemonStoragePage.razor
+++ b/PokeAutobuilder/Pages/PokemonStoragePage.razor
@@ -15,8 +15,14 @@
 
 <MudPaper Elevation="25" Square="true">
     <MudToolBar>
-        <MudIconButton Icon="@Icons.Material.Outlined.Add" OnClick="@(() => _storagePanel = StoragePanel.Add)" />
-        <MudIconButton Icon="@Icons.Material.Outlined.Edit" OnClick="@(() => _storagePanel = StoragePanel.Edit)"  />
+        <MudToggleGroup T="StoragePanel" @bind-Value="_storagePanel">
+            <MudToggleItem Value="StoragePanel.Add">
+                <MudIcon Icon="@Icons.Material.Outlined.Add" />
+            </MudToggleItem>
+            <MudToggleItem Value="StoragePanel.Edit" Disabled="@(_selectedPokemon == null)">
+                <MudIcon Icon="@Icons.Material.Outlined.Edit" />
+            </MudToggleItem>
+        </MudToggleGroup>
     </MudToolBar>
 </MudPaper>
 <div class="d-flex flex-wrap">

--- a/PokeAutobuilder/Pages/TeamBuilderPage.razor
+++ b/PokeAutobuilder/Pages/TeamBuilderPage.razor
@@ -24,7 +24,16 @@
                 @foreach (ILazyPokemonList list in SearchLocations!)
                 {
                     <MudSelectItem T="ILazyPokemonList" Value="list" Disabled="@list.IsEmpty()">
-                        @list.Name
+                        @if (Profile.PokemonStorage.Boxes.Contains(list))
+                        {
+                            <MudText Color="Color.Dark" Typo="Typo.caption">Box - </MudText>
+                            @list.Name
+                        }
+                        else
+                        {
+                            <MudText Color="Color.Dark" Typo="Typo.caption">Pokédex - </MudText>
+                            @list.Name
+                        }                        
                     </MudSelectItem>
                     @if (Profile.PokemonStorage.Boxes.LastOrDefault() == list)
                     {
@@ -62,6 +71,12 @@
     {
         <MudButton OnClick="OnClickAutoBuilder" Color="Color.Primary" StartIcon="@Icons.Material.Filled.SmartToy" Size="Size.Large" Variant="Variant.Filled" Style="max-width: 500px;">Auto Builder</MudButton>
     }
+    <MudStack Row="true" AlignItems="AlignItems.End">
+        <MudText Typo="Typo.caption">Selected Box:</MudText>
+        <MudPaper Class="px-1">
+            <MudText Typo="Typo.subtitle2">@(_selectedBox is null ? "none" : _selectedBox.Name)</MudText>
+        </MudPaper>
+    </MudStack>
     <MudDivider DividerType="DividerType.FullWidth" />
     <MudText Typo="Typo.h6">Pokémon Team Stats</MudText>
     <div style="width: 100%; text-align: center;">
@@ -222,6 +237,7 @@
 
         _teamName = Session.Team.Name;
         _searchLocation = SearchLocations!.Where((s) => s.Name.Equals(Session.SearchLocation)).FirstOrDefault();
+        _selectedBox = Profile.PokemonStorage.Boxes.FirstOrDefault(b => b == _searchLocation);
     }
 
     protected override void OnAfterRender(bool firstRender)

--- a/PokeAutobuilder/Pages/TeamBuilderPage.razor
+++ b/PokeAutobuilder/Pages/TeamBuilderPage.razor
@@ -23,9 +23,13 @@
             @bind-Value="SearchLocation">
                 @foreach (ILazyPokemonList list in SearchLocations!)
                 {
-                    <MudSelectItem T="ILazyPokemonList" Value="list">
+                    <MudSelectItem T="ILazyPokemonList" Value="list" Disabled="@list.IsEmpty()">
                         @list.Name
                     </MudSelectItem>
+                    @if (Profile.PokemonStorage.Boxes.LastOrDefault() == list)
+                    {
+                        <MudDivider DividerType="DividerType.Middle" />
+                    }
                 }
             </MudSelect>
         </MudItem>
@@ -87,9 +91,16 @@
             if (value is not null)
             {
                 _ = Session.SetSearchLocationAsync(value.Name);
+
+                if (value is PokemonBox)
+                {
+                    _selectedBox = value as PokemonBox;
+                }
             }
         }
     }
+
+    private PokemonBox? _selectedBox = null;
 
     private string _teamName { get; set; } = "";
 
@@ -109,8 +120,11 @@
 
     public string GetAutoBuilderTooltipMessage()
     {
-        if (Profile.PokemonStorage.Boxes[0].Pokemon.Count < cards.Count(c => !c.Locked || (c.Locked && c.Pokemon is not null)) + 1)
-            return "Please add more Pokémon to storage in order to use the Auto Builder";
+        if (_selectedBox is null)
+            return "Please select one of your storage boxes by choosing one in the 'Search Location' dropdown menu";
+
+        if (_selectedBox.Pokemon.Count < cards.Count(c => !c.Locked || (c.Locked && c.Pokemon is not null)) + 1)
+            return "Please add more Pokémon to the selected box in order to use the Auto Builder";
 
         if (cards.Count(c => !c.Locked) < 2)
             return "Please unlock some more Pokémon before using the Auto Builder";
@@ -134,7 +148,7 @@
             }
         }
         parameters.Add("InputTeam", inputTeam);
-
+        parameters.Add("InputBox", _selectedBox);
 
         var dialog = await DialogService.ShowAsync<AutoBuilderDialog>("Automatic Team Builder", parameters);
         var result = await dialog.Result;
@@ -196,7 +210,8 @@
 
     protected bool CanRunAutoBuilder()
     {
-        return Profile.PokemonStorage.Boxes[0].Pokemon.Count >= cards.Count(c => !c.Locked || (c.Locked && c.Pokemon is not null)) + 1
+        return _selectedBox is not null
+        && _selectedBox.Pokemon.Count >= cards.Count(c => !c.Locked || (c.Locked && c.Pokemon is not null)) + 1
         && cards.Count(c => !c.Locked) >= 2;
     }
 

--- a/PokeAutobuilder/PokeAutobuilder.csproj
+++ b/PokeAutobuilder/PokeAutobuilder.csproj
@@ -37,6 +37,7 @@
   <ItemGroup>
     <PackageReference Include="Accord.Genetic" Version="3.8.0" />
     <PackageReference Include="Blazor-Analytics" Version="3.12.0" />
+    <PackageReference Include="Blazor-ApexCharts" Version="6.0.1" />
     <PackageReference Include="Blazored.LocalStorage" Version="4.5.0" />
     <PackageReference Include="Blazored.SessionStorage" Version="2.4.0" />
     <PackageReference Include="GeneticSharp" Version="3.1.4" />

--- a/PokeAutobuilder/Program.cs
+++ b/PokeAutobuilder/Program.cs
@@ -36,6 +36,13 @@ builder.Services.AddMudServices(
         config.SnackbarConfiguration.ShowTransitionDuration = 500;
         config.SnackbarConfiguration.SnackbarVariant = Variant.Filled;
     });
+builder.Services.AddApexCharts(e =>
+{
+    e.GlobalOptions = new ApexChartBaseOptions
+    {
+        Theme = new Theme { Palette = PaletteType.Palette7 }
+    };
+});
 builder.Services.AddBlazoredLocalStorage();
 builder.Services.AddBlazoredSessionStorage();
 builder.Services.AddScoped<ProfileService>();

--- a/PokeAutobuilder/Program.cs
+++ b/PokeAutobuilder/Program.cs
@@ -40,7 +40,7 @@ builder.Services.AddApexCharts(e =>
 {
     e.GlobalOptions = new ApexChartBaseOptions
     {
-        Theme = new Theme { Palette = PaletteType.Palette7 }
+        Theme = new Theme { Palette = PaletteType.Palette7 },
     };
 });
 builder.Services.AddBlazoredLocalStorage();

--- a/PokeAutobuilder/Program.cs
+++ b/PokeAutobuilder/Program.cs
@@ -40,7 +40,7 @@ builder.Services.AddApexCharts(e =>
 {
     e.GlobalOptions = new ApexChartBaseOptions
     {
-        Theme = new Theme { Palette = PaletteType.Palette7 },
+        Theme = new Theme { Palette = PaletteType.Palette6 },
     };
 });
 builder.Services.AddBlazoredLocalStorage();

--- a/PokeAutobuilder/Program.cs
+++ b/PokeAutobuilder/Program.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using MudBlazor.Services;
 using MudBlazor;
+using ApexCharts;
 using PokeAutobuilder.Source.Services;
 using PokeAutobuilder;
 using PokemonDataModel;

--- a/PokeAutobuilder/Shared/AutoBuilderDialog.razor
+++ b/PokeAutobuilder/Shared/AutoBuilderDialog.razor
@@ -300,8 +300,11 @@
     [CascadingParameter]
     IMudDialogInstance? MudDialog { get; set; }
 
-    [Parameter]
+    [Parameter, EditorRequired]
     public List<Tuple<SmartPokemon?, int>>? InputTeam { get; set; }
+
+    [Parameter, EditorRequired]
+    public PokemonBox? InputBox { get; set; }
 
     private PokemonTeamGeneticAlgorithm GeneticAlgorithm = new PokemonTeamGeneticAlgorithm();
     private PokemonTeam BestTeam = new PokemonTeam();
@@ -395,7 +398,7 @@
 
         GeneticAlgorithm.Initialize(
             PopulationSize
-            , Profile.PokemonStorage.Boxes[0]
+            , InputBox!
             , lockedMembers
             , weightingsCopy);
         GeneticAlgorithm.RunInBackground();

--- a/PokeAutobuilder/Shared/Cards/PokemonCard.razor
+++ b/PokeAutobuilder/Shared/Cards/PokemonCard.razor
@@ -10,11 +10,15 @@
 @if (Pokemon is not null && _generation is not null)
 {
     <MudStack AlignItems="AlignItems.Center" Spacing="1">
-        <MudImage Fluid="true" Src="@Pokemon.Sprites.Other.OfficialArtwork.FrontDefault" alt="@Pokemon.Name" title="@Pokemon.Name" Style="-webkit-filter: drop-shadow(5px 5px 5px #222); filter: drop-shadow(5px 5px 5px #222);" />
+        <MudTooltip Text="@Pokemon.Name">
+            <MudImage Fluid="true" Src="@Pokemon.Sprites.Other.OfficialArtwork.FrontDefault" alt="@Pokemon.Name" Style="-webkit-filter: drop-shadow(5px 5px 5px #222); filter: drop-shadow(5px 5px 5px #222);" />
+        </MudTooltip>
         <MudStack Row="true" Class="pa-2">
             @foreach (PokemonType t in Pokemon.Types)
             {
-                <MudImage Src="@StringUtils.TypeImgFromName(t.Type.Name)" alt="@t.Type.Name" title="@t.Type.Name" Width="50"/>
+                <MudTooltip Text="@StringUtils.PrettifyString(t.Type.Name)">
+                    <MudImage Src="@StringUtils.TypeImgFromName(t.Type.Name)" alt="@t.Type.Name" Width="50" />
+                </MudTooltip>                
             }
         </MudStack>
         @if (IsNameDisplayed)

--- a/PokeAutobuilder/Shared/Cards/PokemonMiniCard.razor
+++ b/PokeAutobuilder/Shared/Cards/PokemonMiniCard.razor
@@ -5,7 +5,7 @@
 @using PokemonDataModel
 @using Utility
 
-<MudTooltip Text="@Pokemon!.Name">
+<MudTooltip Text="@Pokemon!.ToString()">
 	<MudButton Class="ma-2" Color="Color.Surface" OnClick="OnClickCard" Variant="@Variant">
 		<MudImage
 			Src="@(String.IsNullOrEmpty(Pokemon!.Sprites.FrontDefault) ? Pokemon!.Sprites.Other.OfficialArtwork.FrontDefault : Pokemon!.Sprites.FrontDefault)"

--- a/PokeAutobuilder/Shared/Cards/PokemonTeamCard.razor
+++ b/PokeAutobuilder/Shared/Cards/PokemonTeamCard.razor
@@ -56,7 +56,7 @@
 		var parameters = new DialogParameters();
 		parameters.Add("Team", Team);
 
-		DialogService.ShowAsync<PokemonTeamDetailsDialog>(StringUtils.FirstCharToUpper(Team!.Name), parameters);
+		DialogService.ShowAsync<PokemonTeamDetailsDialog>(StringUtils.PrettifyString(Team!.Name), parameters);
 	}
 
 	public async void OnClickLoadInEditor()

--- a/PokeAutobuilder/Shared/MainLayout.razor
+++ b/PokeAutobuilder/Shared/MainLayout.razor
@@ -156,8 +156,8 @@
 
             }
 
+            SearchLocations.AddRange(Profile.PokemonStorage.Boxes);
             SearchLocations.Add(new SmartPokedex("National Pokédex", new NamedApiResource<Pokedex> { Name = "national", Url = "https://pokeapi.co/api/v2/pokedex/1/" }));
-            if (Profile.PokemonStorage is not null) SearchLocations.Add(Profile.PokemonStorage.Boxes[0]);
             SearchLocations.Add(new SmartPokedex("Red & Blue", new NamedApiResource<VersionGroup> { Name = "red-blue", Url = "https://pokeapi.co/api/v2/version-group/1/" }));
             SearchLocations.Add(new SmartPokedex("Yellow", new NamedApiResource<VersionGroup> { Name = "yellow", Url = "https://pokeapi.co/api/v2/version-group/2/" }));
             SearchLocations.Add(new SmartPokedex("Gold & Silver", new NamedApiResource<VersionGroup> { Name = "gold-silver", Url = "https://pokeapi.co/api/v2/version-group/3/" }));

--- a/PokeAutobuilder/Shared/MainLayout.razor
+++ b/PokeAutobuilder/Shared/MainLayout.razor
@@ -9,6 +9,7 @@
 @inject PokeApiService PokeApiService
 @inject IAnalytics GlobalTracking
 @inject IJSRuntime JS
+@inject ApexCharts.IApexChartService ApexChartService;
 
 
 <MudThemeProvider @ref="_themeProvider" @bind-IsDarkMode="@_isDarkMode" Theme="AutoBuilderTheme" />
@@ -35,7 +36,7 @@
     <MudDrawer @bind-Open="@_open" Elevation="1" ClipMode="DrawerClipMode.Always">
         <NavMenu />
         <MudDivider />
-        <MudSwitch @bind-Value="@_IsDarkMode" Color="Color.Primary" Class="ma-4 object-bottom" T="bool" Label="Dark Mode" />
+        <MudSwitch @bind-Value="@IsDarkMode" Color="Color.Primary" Class="ma-4 object-bottom" T="bool" Label="Dark Mode" />
     </MudDrawer>
     <MudMainContent Class="pt-16 mud-height-full">
         <MudContainer Class="mt-6" MaxWidth="MaxWidth.ExtraLarge">
@@ -70,12 +71,16 @@
 
     // theme stuff
     private bool _isDarkMode;
-    private bool _IsDarkMode
+    private bool IsDarkMode
     {
         get { return _isDarkMode; }
         set
         {
             _isDarkMode = value;
+            ApexChartService.SetGlobalOptionsAsync(new ApexCharts.ApexChartBaseOptions()
+            {
+                Theme = new ApexCharts.Theme { Palette = ApexCharts.PaletteType.Palette7, Mode = value ? ApexCharts.Mode.Dark : ApexCharts.Mode.Light }
+            }, true);
             OnChangeDarkMode();
         }
     }
@@ -138,7 +143,7 @@
             // initialising global variables used across the app
             // load preferences first before the slow ones
             Preferences prefs = await Profile.GetPreferencesAsync();
-            _isDarkMode = prefs.DarkMode;
+            IsDarkMode = prefs.DarkMode;
 
             StateHasChanged();
 
@@ -191,7 +196,7 @@
 
     void OnChangeDarkMode()
     {
-        Profile?.SetDarkModeAsync(_IsDarkMode);
+        Profile?.SetDarkModeAsync(IsDarkMode);
     }
 
     // nav menu

--- a/PokeAutobuilder/Shared/Panes/PokemonCoveragePane.razor
+++ b/PokeAutobuilder/Shared/Panes/PokemonCoveragePane.razor
@@ -6,24 +6,24 @@
 	<div class="d-flex flex-column align-center justify-center">
 		<MudStack Spacing="5" AlignItems="AlignItems.Center" Style="width: 100%;" Class="pa-2">
 			<MudText Typo="Typo.subtitle1" Class="mb-2">Coverage</MudText>
-			<MudStack Row="true" Style="width: 100%;" AlignItems="AlignItems.Center">
-				<MudText Typo="Typo.caption" Class="mr-1" Style="width: 80px">STAB</MudText>
-				<MudGrid>
-					@foreach (string t in Globals.AllTypes)
+			<MudStack Row="true" Style="width: 100%;" AlignItems="AlignItems.Center" Spacing="0">
+				<MudText Typo="Typo.caption" Class="mr-1" Style="width: 50px;">STAB</MudText>
+				<div class="d-flex flex-wrap justify-start align-content-start">
+				@foreach (string t in Globals.AllTypes)
+				{
+					@if (Pokemon.IsTypeCoveredBySTAB(t))
 					{
-						@if (Pokemon.IsTypeCoveredBySTAB(t))
-						{
-							<MudTooltip Text="@StringUtils.PrettifyString(t)">
+						<MudTooltip Text="@StringUtils.PrettifyString(t)">
 							<MudImage Src="@StringUtils.TypeImgFromName(t)" Alt="@t" Height="20" Class="ma-1" />
-							</MudTooltip>
-						}
+						</MudTooltip>
 					}
-				</MudGrid>
+				}
+				</div>
 			</MudStack>
 			<MudDivider />
-			<MudStack Row="true" Style="width: 100%;" AlignItems="AlignItems.Center">
-				<MudText Typo="Typo.caption" Class="mr-1" Style="width: 80px">Moves</MudText>
-				<MudGrid>
+			<MudStack Row="true" Style="width: 100%;" AlignItems="AlignItems.Center" Spacing="0">
+				<MudText Typo="Typo.caption" Class="mr-1" Style="width: 60px">Moves</MudText>
+				<div class="d-flex flex-wrap justify-start align-content-start">
 					@foreach (string t in Globals.AllTypes)
 					{
 						@if (Pokemon.IsTypeCoveredByMove(t))
@@ -33,7 +33,7 @@
 							</MudTooltip>
 						}
 					}
-				</MudGrid>
+				</div>
 			</MudStack>
 		</MudStack>
 	</div>

--- a/PokeAutobuilder/Shared/Panes/PokemonCoveragePane.razor
+++ b/PokeAutobuilder/Shared/Panes/PokemonCoveragePane.razor
@@ -13,7 +13,9 @@
 					{
 						@if (Pokemon.IsTypeCoveredBySTAB(t))
 						{
-							<MudImage Src="@StringUtils.TypeImgFromName(t)" Alt="@t" title="@t" Height="20" Class="ma-1" />
+							<MudTooltip Text="@StringUtils.PrettifyString(t)">
+							<MudImage Src="@StringUtils.TypeImgFromName(t)" Alt="@t" Height="20" Class="ma-1" />
+							</MudTooltip>
 						}
 					}
 				</MudGrid>
@@ -26,7 +28,9 @@
 					{
 						@if (Pokemon.IsTypeCoveredByMove(t))
 						{
-							<MudImage Src="@StringUtils.TypeImgFromName(t)" Alt="@t" title="@t" Height="20" Class="ma-1" />
+							<MudTooltip Text="@StringUtils.PrettifyString(t)">
+							<MudImage Src="@StringUtils.TypeImgFromName(t)" Alt="@t" Height="20" Class="ma-1" />
+							</MudTooltip>
 						}
 					}
 				</MudGrid>

--- a/PokeAutobuilder/Shared/Panes/PokemonDefensePane.razor
+++ b/PokeAutobuilder/Shared/Panes/PokemonDefensePane.razor
@@ -14,7 +14,9 @@
 						@if (Pokemon.GetResistance(t) < 1.0)
 						{
 							<MudStack Spacing="0" Class="d-flex flex-column align-center justify-center ma-1">
-								<MudImage Src="@StringUtils.TypeImgFromName(t)" Alt="@t" title="@t" Height="20" />
+								<MudTooltip Text="@StringUtils.PrettifyString(t)">
+									<MudImage Src="@StringUtils.TypeImgFromName(t)" Alt="@t" Height="20" Class="ma-1" />
+								</MudTooltip>
 								@if (Pokemon.GetResistance(t) == 0.5)
 								{
 									<MudText Typo="Typo.caption">½x</MudText>
@@ -41,7 +43,9 @@
 						@if (Pokemon.GetResistance(t) > 1.0)
 						{
 							<MudStack Spacing="0" Class="d-flex flex-column align-center justify-center ma-1">
-								<MudImage Src="@StringUtils.TypeImgFromName(t)" Alt="@t" title="@t" Height="20" />
+								<MudTooltip Text="@StringUtils.PrettifyString(t)">
+									<MudImage Src="@StringUtils.TypeImgFromName(t)" Alt="@t" Height="20" Class="ma-1" />
+								</MudTooltip>
 								@if (Pokemon.GetResistance(t) <= 2.0)
 								{
 									<MudText Typo="Typo.caption">@(Pokemon.GetResistance(t))x</MudText>

--- a/PokeAutobuilder/Shared/Panes/PokemonDefensePane.razor
+++ b/PokeAutobuilder/Shared/Panes/PokemonDefensePane.razor
@@ -6,9 +6,9 @@
 	<div class="d-flex flex-column align-center justify-center">
 		<MudStack Spacing="5" AlignItems="AlignItems.Center" Style="width: 100%;" Class="pa-2">
 			<MudText Typo="Typo.subtitle1" Class="mb-2">Type Defense</MudText>
-			<MudStack Row="true" Style="width: 100%;" AlignItems="AlignItems.Center">
-				<MudText Typo="Typo.caption" Class="mr-1" Style="width: 80px">Resist</MudText>
-				<MudGrid>
+			<MudStack Row="true" Style="width: 100%;" AlignItems="AlignItems.Center" Spacing="0">
+				<MudText Typo="Typo.caption" Class="mr-1" Style="width: 50px">Resist</MudText>
+				<div class="d-flex flex-wrap justify-start align-content-start">
 					@foreach (string t in Globals.AllTypes)
 					{
 						@if (Pokemon.GetResistance(t) < 1.0)
@@ -32,12 +32,12 @@
 							</MudStack>
 						}
 					}
-				</MudGrid>
+				</div>
 			</MudStack>
 			<MudDivider />
-			<MudStack Row="true" Style="width: 100%;" AlignItems="AlignItems.Center">
-				<MudText Typo="Typo.caption" Class="mr-1" Style="width: 80px">Weak</MudText>
-				<MudGrid>
+			<MudStack Row="true" Style="width: 100%;" AlignItems="AlignItems.Center" Spacing="0">
+				<MudText Typo="Typo.caption" Class="mr-1" Style="width: 50px">Weak</MudText>
+				<div class="d-flex flex-wrap justify-start align-content-start">
 					@foreach (string t in Globals.AllTypes)
 					{
 						@if (Pokemon.GetResistance(t) > 1.0)
@@ -57,7 +57,7 @@
 							</MudStack>
 						}
 					}
-				</MudGrid>
+				</div>
 			</MudStack>
 		</MudStack>
 	</div>

--- a/PokeAutobuilder/Shared/Panes/PokemonStatsChartPane.razor
+++ b/PokeAutobuilder/Shared/Panes/PokemonStatsChartPane.razor
@@ -3,40 +3,25 @@
 
 @if (Pokemon is not null)
 {
-	<div class="d-flex flex-column align-center justify-center mud-width-full">
-		<MudText Typo="Typo.subtitle1">Base Stats</MudText>
-		<MudChart ChartType="ChartType.Donut" LegendPosition="Position.Left" Width="auto" Height="100%"
-		InputData="@Data" InputLabels="@Labels" @bind-SelectedIndex="SelectedIndex" @onmouseout="OnMouseLeaveChart">
-			<CustomGraphics>
-				<text class="donut-inner-text" x="50%" y="40%" dominant-baseline="middle" text-anchor="middle" fill="var(--mud-palette-text-primary)" font-family="Helvetica" font-size="2">Total</text>
-				<text class="donut-inner-text" x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="var(--mud-palette-text-primary)" font-family="Helvetica" font-size="5">@Pokemon.GetBaseStatsTotal()</text>
-				<MudPopover Open="@IsTooltipOpen" Class="pa-1" AnchorOrigin="Origin.CenterCenter" TransformOrigin="Origin.TopCenter">
-					<MudText>@GetChartTooltip()</MudText>
-				</MudPopover>
-			</CustomGraphics>
-		</MudChart>
-
-		<ApexCharts.ApexChart TItem="StatItem" Title="Base Stats">
+	<div class="d-flex flex-column align-center justify-center mud-width-full mud-height-full">
+		<ApexCharts.ApexChart @ref="_chart" TItem="StatItem" Title="Base Stats" Options="_options">
 			<ApexCharts.ApexPointSeries TItem="StatItem"
                     Items="_stats"
-                    Name="Gross Value"
+                    Name="Base Stat"
                     XValue="@(e => e.Name)"
-					SeriesType="ApexCharts.SeriesType.Bar"
+					YValue="@(e => (int)Math.Round(e.Value))"
+					SeriesType="ApexCharts.SeriesType.Bar"					
                     Color="#005ba3"
                     PointColor="e=> GetStatColour(e)" />
 		</ApexCharts.ApexChart>
 	</div>
 }
 
-<style>
-	.mud-chart .mud-chart-legend {
-		min-width: 80px;
-	}
-</style>
-
 @code {
 	[Parameter]
 	public SmartPokemon? Pokemon { get; set; }
+
+	private SmartPokemon? _prevPokemon;
 
 	private class StatItem
 	{
@@ -46,54 +31,91 @@
 
 	private List<StatItem> _stats = [];
 
-	public double[] Data = new double[6];
-	private int selectedIndex;
-	public int SelectedIndex
+	private ApexCharts.ApexChart<StatItem>? _chart;
+
+	private ApexCharts.ApexChartOptions<StatItem> _options = new()
 	{
-		get
+		Title = new ApexCharts.Title()
 		{
-			return selectedIndex;
-		}
-		set
+			Style = new ApexCharts.TitleStyle()
+			{
+				FontFamily = "var(--mud-typography-subtitle1-family)",
+				FontWeight = "normal",
+				FontSize = "1rem",
+			},
+
+			Align = ApexCharts.Align.Center,
+			OffsetY = 20,
+		},
+
+		Chart = new ApexCharts.Chart()
 		{
-			selectedIndex = value;
-			IsTooltipOpen = true;
+			Background = "transparent",
+			FontFamily = "var(--mud-typography-subtitle1-family);",
+		},
+
+		PlotOptions = new ApexCharts.PlotOptions()
+		{
+			Bar = new ApexCharts.PlotOptionsBar
+			{
+				Horizontal = true,
+				Colors = new ApexCharts.PlotOptionsBarColors()
+				{
+					BackgroundBarOpacity = 0
+				}
+			}
 		}
-	}
+	};
+
 	public string[] Labels = { "HP", "Attack", "Sp. Att", "Defense", "Sp. Def", "Speed" };
 
-	public bool IsTooltipOpen = false;
-
-	// when component is initialised
-	protected override void OnParametersSet()
+	protected override async Task OnParametersSetAsync()
 	{
-		if (Pokemon is not null)
+		if (Pokemon is not null
+			&& _prevPokemon != Pokemon)
 		{
+			_stats.Clear();
 			double[] statsArray = Pokemon.GetBaseStatsArray();
 			for (var i = 0; i < statsArray.Length; i++)
 			{
 				_stats.Add(new() { Name = Labels[i], Value = statsArray[i] });
 			}
-		}
-	}
 
-	public string GetChartTooltip()
-	{
-		if (SelectedIndex >= 0 && SelectedIndex < Data.Length)
-		{
-			return Labels[SelectedIndex] + ": " + Data[SelectedIndex];
-		}
+			if (_prevPokemon is not null)
+			{
+				await _chart!.RenderAsync();
+			}
 
-		return "";
+			_prevPokemon = Pokemon;
+		}
 	}
 
 	private string GetStatColour(StatItem stat)
 	{
-		return "#00ff00";
-	}
+		double value = stat.Value;
 
-	public void OnMouseLeaveChart()
-	{
-		IsTooltipOpen = false;
+		// Clamp between 0 and 255
+		value = Math.Max(0, Math.Min(255, value));
+
+		int r, g, b;
+
+		if (value <= 127.5)
+		{
+			// Red to Green
+			double t = value / 127.5;
+			r = (int)(255 * (1 - t));   // Red fades out
+			g = (int)(255 * t);         // Green fades in
+			b = 0;
+		}
+		else
+		{
+			// Green to Blue
+			double t = (value - 127.5) / 127.5;
+			r = 0;
+			g = (int)(255 * (1 - t));   // Green fades out
+			b = (int)(255 * t);         // Blue fades in
+		}
+
+		return $"#{r:X2}{g:X2}{b:X2}";
 	}
 }

--- a/PokeAutobuilder/Shared/Panes/PokemonStatsChartPane.razor
+++ b/PokeAutobuilder/Shared/Panes/PokemonStatsChartPane.razor
@@ -15,6 +15,16 @@
 				</MudPopover>
 			</CustomGraphics>
 		</MudChart>
+
+		<ApexCharts.ApexChart TItem="StatItem" Title="Base Stats">
+			<ApexCharts.ApexPointSeries TItem="StatItem"
+                    Items="_stats"
+                    Name="Gross Value"
+                    XValue="@(e => e.Name)"
+					SeriesType="ApexCharts.SeriesType.Bar"
+                    Color="#005ba3"
+                    PointColor="e=> GetStatColour(e)" />
+		</ApexCharts.ApexChart>
 	</div>
 }
 
@@ -27,6 +37,14 @@
 @code {
 	[Parameter]
 	public SmartPokemon? Pokemon { get; set; }
+
+	private class StatItem
+	{
+		public string Name = string.Empty;
+		public double Value;
+	}
+
+	private List<StatItem> _stats = [];
 
 	public double[] Data = new double[6];
 	private int selectedIndex;
@@ -51,7 +69,11 @@
 	{
 		if (Pokemon is not null)
 		{
-			Data = Pokemon.GetBaseStatsArray();
+			double[] statsArray = Pokemon.GetBaseStatsArray();
+			for (var i = 0; i < statsArray.Length; i++)
+			{
+				_stats.Add(new() { Name = Labels[i], Value = statsArray[i] });
+			}
 		}
 	}
 
@@ -63,6 +85,11 @@
 		}
 
 		return "";
+	}
+
+	private string GetStatColour(StatItem stat)
+	{
+		return "#00ff00";
 	}
 
 	public void OnMouseLeaveChart()

--- a/PokeAutobuilder/Shared/Panes/PokemonStatsChartPane.razor
+++ b/PokeAutobuilder/Shared/Panes/PokemonStatsChartPane.razor
@@ -45,11 +45,15 @@
 			},
 
 			Align = ApexCharts.Align.Center,
-			OffsetY = 20,
+			OffsetY = 25,
 		},
 
 		Chart = new ApexCharts.Chart()
 		{
+			Toolbar = new ApexCharts.Toolbar
+			{
+				Show = false
+			},
 			Background = "transparent",
 			FontFamily = "var(--mud-typography-subtitle1-family);",
 		},
@@ -59,10 +63,6 @@
 			Bar = new ApexCharts.PlotOptionsBar
 			{
 				Horizontal = true,
-				Colors = new ApexCharts.PlotOptionsBarColors()
-				{
-					BackgroundBarOpacity = 0
-				}
 			}
 		}
 	};

--- a/PokeAutobuilder/Shared/Panes/PokemonStatsChartPane.razor
+++ b/PokeAutobuilder/Shared/Panes/PokemonStatsChartPane.razor
@@ -3,8 +3,8 @@
 
 @if (Pokemon is not null)
 {
-	<div class="d-flex flex-column align-center justify-center mud-width-full mud-height-full">
-		<ApexCharts.ApexChart @ref="_chart" TItem="StatItem" Title="Base Stats" Options="_options">
+	<div class="mud-width-full mud-height-full" style="min-height: 200px;">
+		<ApexCharts.ApexChart @ref="_chart" TItem="StatItem" Title="@($"Base Stats\tTotal: {(int)_stats.Sum(stat => stat.Value)}")" Options="_options">
 			<ApexCharts.ApexPointSeries TItem="StatItem"
                     Items="_stats"
                     Name="Base Stat"
@@ -56,6 +56,8 @@
 			},
 			Background = "transparent",
 			FontFamily = "var(--mud-typography-subtitle1-family);",
+			Width = "100%",
+			Height = "100%",
 		},
 
 		PlotOptions = new ApexCharts.PlotOptions()

--- a/PokeAutobuilder/Shared/Panes/PokemonTeamStatsChartPane.razor
+++ b/PokeAutobuilder/Shared/Panes/PokemonTeamStatsChartPane.razor
@@ -42,7 +42,7 @@
 				// need to add an empty value to get the chart to draw correctly >:(
 				List<double> stats = new List<double>(p.GetBaseStatsArray());
 				stats.Add(0);
-				TeamStats.Add(new ChartSeries() { Name = StringUtils.FirstCharToUpper(p.Name), Data = stats.ToArray() });
+				TeamStats.Add(new ChartSeries() { Name = StringUtils.PrettifyString(p.Name), Data = stats.ToArray() });
 
 				// for finding average total base stats
 				TotalBaseStats += p.GetBaseStatsTotal();

--- a/PokeAutobuilder/Shared/Panes/PokemonTeamStatsChartPane.razor
+++ b/PokeAutobuilder/Shared/Panes/PokemonTeamStatsChartPane.razor
@@ -1,54 +1,117 @@
 ﻿@using PokemonDataModel
 @using Utility
 
-<MudPaper Class="d-flex flex-column align-center justify-center mud-width-full pa-2">
-	<MudText Typo="Typo.h6">Team Base Stats</MudText>
-	<MudText Typo="Typo.body1">Total Base Stat Average: @AverageTotalBaseStats</MudText>
-	<MudChart ChartType="ChartType.Bar" ChartSeries="@TeamStats" @bind-SelectedIndex="Index" XAxisLabels="@Labels" Width="100%" Style="width: 95%;"></MudChart>
-</MudPaper>
+@if (Team is not null)
+{
+	<div class="mud-width-full mud-height-full" style="min-height: 250px;">
+		<ApexCharts.ApexChart @ref="_chart" 
+							  TItem="StatItem"
+							  Title="@($"Base Stats\tAverage Total: {(int)_stats.Sum(statList => statList.Item2.Sum(stat => stat.Value) / _stats.Count)}")"
+							  Options="_options">
+
+			@foreach (var (pokemonName, statList) in _stats)
+			{
+				<ApexCharts.ApexPointSeries TItem="StatItem"
+											Items="statList"
+											Name="@pokemonName"
+											XValue="@(e => e.Name)"
+											YValue="@(e => (int)Math.Round(e.Value))"
+											SeriesType="ApexCharts.SeriesType.Bar"
+											Color="@GetStatColour(statList)" />
+			}
+
+		</ApexCharts.ApexChart>
+	</div>
+}
 
 @code {
 	[Parameter]
 	public PokemonTeam? Team { get; set; }
 
-	// team base stats stuff
-	private int Index = -1; //default value cannot be 0 -> first selectedindex is 0.
-	public List<ChartSeries> TeamStats = new List<ChartSeries>();
-	public string[] Labels = { "HP", "Attack", "Sp. Att", "Defense", "Sp. Def", "Speed" };
+	private PokemonTeam? _prevTeam;
 
-	private double TotalBaseStats = 0;
-	private int AverageTotalBaseStats = 0;
-
-	// when component is initialised
-	protected override void OnInitialized()
+	private class StatItem
 	{
-		OnParametersSet();
+		public string Name = string.Empty;
+		public double Value;
 	}
 
+	private ApexCharts.ApexChart<StatItem>? _chart;
+
+	private ApexCharts.ApexChartOptions<StatItem> _options = new()
+	{
+		Title = new ApexCharts.Title()
+		{
+			Style = new ApexCharts.TitleStyle()
+			{
+				FontFamily = "var(--mud-typography-subtitle1-family)",
+				FontWeight = "normal",
+				FontSize = "1rem",
+			},
+
+			Align = ApexCharts.Align.Center,
+			OffsetY = 25,
+		},
+
+		Chart = new ApexCharts.Chart()
+		{
+			Stacked = true,
+			Toolbar = new ApexCharts.Toolbar
+			{
+				Show = false
+			},
+			Background = "transparent",
+			FontFamily = "var(--mud-typography-subtitle1-family);",
+			Width = "100%",
+			Height = "100%",
+		},
+
+		PlotOptions = new ApexCharts.PlotOptions()
+		{
+			Bar = new ApexCharts.PlotOptionsBar
+			{
+				Horizontal = true,
+				ColumnWidth = "20%",
+			},
+		}
+	};
+
+
+	private List<Tuple<string, List<StatItem>>> _stats = [];
+
+	public string[] Labels = { "HP", "Attack", "Sp. Att", "Defense", "Sp. Def", "Speed" };
+	public string[] Colours = { "#F44336", "#009688", "#3F51B5", "#4CAF50", "#2196F3", "#FF5722" };
 
 	protected override void OnParametersSet()
 	{
-		if (Team is null)
+		if (Team is null || _prevTeam == Team)
 			return;
 
-		TeamStats = new List<ChartSeries>();
-		TotalBaseStats = 0;
-		AverageTotalBaseStats = 0;
-
+		_stats.Clear();
 		foreach (SmartPokemon? p in Team.Pokemon)
 		{
 			if (p is not null)
 			{
-				// need to add an empty value to get the chart to draw correctly >:(
-				List<double> stats = new List<double>(p.GetBaseStatsArray());
-				stats.Add(0);
-				TeamStats.Add(new ChartSeries() { Name = StringUtils.PrettifyString(p.Name), Data = stats.ToArray() });
-
-				// for finding average total base stats
-				TotalBaseStats += p.GetBaseStatsTotal();
+				double[] statsArray = p.GetBaseStatsArray();
+				List<StatItem> pokemonStatList = [];
+				for (var i = 0; i < statsArray.Length; i++)
+				{
+					pokemonStatList.Add(new() { Name = Labels[i], Value = statsArray[i] });
+				}
+				_stats.Add(new(p.ToString(), pokemonStatList));
 			}
 		}
 
-		AverageTotalBaseStats = (int)(TotalBaseStats / Team.CountPokemon());
+		if (_prevTeam is not null)
+		{
+			_ = _chart!.RenderAsync();
+		}
+
+		_prevTeam = Team;
+	}
+
+	private string GetStatColour(List<StatItem> statList)
+	{
+		return Colours[_stats.FindIndex(e => e.Item2 == statList)];
 	}
 }

--- a/PokeAutobuilder/Shared/PokemonDetails.razor
+++ b/PokeAutobuilder/Shared/PokemonDetails.razor
@@ -77,7 +77,7 @@
             }
         </MudPaper>
     </MudItem>
-    <MudItem xs="12" md="6">        
+    <MudItem xs="12" sm="6">        
         @if (Pokemon is not null)
         {
             <MudPaper Height="100%" Style="background-color: var(--mud-palette-background)"

--- a/PokeAutobuilder/Shared/PokemonDetails.razor
+++ b/PokeAutobuilder/Shared/PokemonDetails.razor
@@ -51,7 +51,7 @@
             }
         </div>
     </MudItem>
-    <MudItem xs="6">
+    <MudItem xs="12" sm="6">
         <MudPaper Height="100%" Style="background-color: var(--mud-palette-background)"
         Outlined="true" Square="true">
             @if (Pokemon is not null)
@@ -64,7 +64,7 @@
             }
         </MudPaper>
     </MudItem>
-    <MudItem xs="6">
+    <MudItem xs="12" sm="6">
         <MudPaper Height="100%" Style="background-color: var(--mud-palette-background)"
         Outlined="true" Square="true">            
             @if (Pokemon is not null)

--- a/PokeAutobuilder/Shared/PokemonDetails.razor
+++ b/PokeAutobuilder/Shared/PokemonDetails.razor
@@ -80,7 +80,12 @@
     <MudItem xs="12" sm="6">        
         @if (Pokemon is not null)
         {
-            <PokemonStatsChartPane Pokemon="@Pokemon" />
+            <MudPaper Height="100%" Style="background-color: var(--mud-palette-background)"
+                Outlined="true" Square="true">  
+
+                <PokemonStatsChartPane Pokemon="@Pokemon" />
+
+            </MudPaper>
         }
         else
         {

--- a/PokeAutobuilder/Shared/PokemonDetails.razor
+++ b/PokeAutobuilder/Shared/PokemonDetails.razor
@@ -77,7 +77,7 @@
             }
         </MudPaper>
     </MudItem>
-    <MudItem xs="12" sm="6">        
+    <MudItem xs="12" md="6">        
         @if (Pokemon is not null)
         {
             <MudPaper Height="100%" Style="background-color: var(--mud-palette-background)"

--- a/PokeAutobuilder/Shared/PokemonSearchBox.razor
+++ b/PokeAutobuilder/Shared/PokemonSearchBox.razor
@@ -11,7 +11,6 @@
 @inject SessionService Session
 @inject PokeApiService PokeApiService
 @inject IDialogService DialogService
-@inject ISnackbar Snackbar
 
 <MudPaper Elevation="4" Class="d-flex flex-column align-center justify-center mud-width-full pa-2" Outlined="true" >
 

--- a/PokeAutobuilder/Shared/PokemonSearchBox.razor
+++ b/PokeAutobuilder/Shared/PokemonSearchBox.razor
@@ -57,10 +57,6 @@
             <MudTooltip Text="Details">
                 <MudIconButton Size="Size.Small" Icon="@Icons.Material.Filled.OpenInFull" OnClick="OnClickDetails"></MudIconButton>
             </MudTooltip>
-            <MudTooltip Text="Add To Storage">
-                <MudIconButton Disabled="@(Profile.PokemonStorage.Boxes[0].Pokemon.Contains(Pokemon))"
-                Size="Size.Small" Icon="@Icons.Material.Filled.Save" OnClick="OnClickAddToStorage"></MudIconButton>
-            </MudTooltip>
             @ExtraButtons
         </MudButtonGroup>
     }
@@ -242,16 +238,6 @@
             _pokemon.SelectAbility(value);
     }
 
-    public async Task OnClickAddToStorage()
-    {
-        if (Pokemon is null)
-            return;
-
-        await Profile.AddPokemonToStorageAsync(Pokemon);
-
-        Snackbar.Add("Added " + Pokemon.ToString() + " to Pokémon Storage", Severity.Success);
-    }
-
     public async Task OnClickDetails()
     {
         var parameters = new DialogParameters();
@@ -263,16 +249,12 @@
         if (result is not null
             && !result.Canceled && result.Data is SmartPokemon)
         {
-            // replace old pokemon with updated version
+            // update the Profile storage if this pokemon exists in there
             SmartPokemon? pokemon = result.Data as SmartPokemon;
-            if (pokemon is not null)
+            if (pokemon is not null
+                && Profile.FindPokemonBoxForPokemon(pokemon) is not null)
             {
-                // add and remove pokemon from storage to "update" it
-                // we can directly remove it here because it's about to be updated
-                // properly by AddPokemonToStorageAsync anyway
-                if (Profile.PokemonStorage.Boxes[0].Pokemon.Remove(pokemon))
-                    await Profile.AddPokemonToStorageAsync(pokemon);
-                Pokemon = pokemon;
+                await Profile.UpdatePokemonStorageAsync();
             }
             StateHasChanged();
         }

--- a/PokeAutobuilder/Shared/PokemonSearchBox.razor
+++ b/PokeAutobuilder/Shared/PokemonSearchBox.razor
@@ -13,16 +13,7 @@
 @inject IDialogService DialogService
 @inject ISnackbar Snackbar
 
-<MudPaper Elevation="4" Class="d-flex flex-column align-center justify-center mud-width-full pa-2">
-
-    <div style="width: 100%;">
-    @if (Lockable)
-    {
-        <MudToggleIconButton @bind-Toggled="@Locked"
-            Icon="@Icons.Material.Filled.LockOpen" Color="@Color.Dark"
-            ToggledIcon="@Icons.Material.Filled.Lock" ToggledColor="@Color.Primary" Style="padding: 0;"/>
-    }
-    </div>
+<MudPaper Elevation="4" Class="d-flex flex-column align-center justify-center mud-width-full pa-2" Outlined="true" >
 
     <MudAutocomplete T="IPokemonSearchable" Label="Pokémon" @bind-Value="PokemonSearchValue" SearchFunc="@(SearchFunc!)"
     ResetValueOnEmptyText="true" Disabled="@_locked" MaxItems="50"
@@ -37,26 +28,35 @@
         </MoreItemsTemplate>
     </MudAutocomplete>
 
-    <div style="height: 50px">
-        @if (_pokemonSearchValueVarieties.Count > 1
-            && !_locked)
-        {
-            <MudSelect Dense="true" T="string" Label="Form" AnchorOrigin="Origin.BottomCenter" TransformOrigin="Origin.TopCenter"
-            @bind-Value="_PokemonFormName">
-                @foreach (var v in _pokemonSearchValueVarieties)
-                {
-                    <MudSelectItem Value="@v.Name" />
-                }
-            </MudSelect>
-        }
-    </div>
     @if (Pokemon is not null)
     {
+        <div style="height: 50px">
+            @if (_pokemonSearchValueVarieties.Count > 1
+                    && !_locked)
+            {
+                <MudSelect Dense="true" T="string" Label="Form" AnchorOrigin="Origin.BottomCenter" TransformOrigin="Origin.TopCenter"
+                           @bind-Value="_PokemonFormName">
+                    @foreach (var v in _pokemonSearchValueVarieties)
+                    {
+                        <MudSelectItem Value="@v.Name" />
+                    }
+                </MudSelect>
+            }
+        </div>
+
         <PokemonCard Pokemon="Pokemon" IsNameDisplayed="false" />
-        <MudButtonGroup Color="Color.Primary" Variant="Variant.Outlined">
+        <MudButtonGroup Color="Color.Primary" Variant="Variant.Text" Size="Size.Small" Class="mt-2">
             <MudTooltip Text="Details">
                 <MudIconButton Size="Size.Small" Icon="@Icons.Material.Filled.OpenInFull" OnClick="OnClickDetails"></MudIconButton>
             </MudTooltip>
+            @if (Lockable)
+            {
+                <MudTooltip Text="Lock slot for Auto Builder">
+                    <MudToggleIconButton @bind-Toggled="@Locked" Color="Color.Dark" ToggledColor="Color.Primary"
+                                         Icon="@Icons.Material.Filled.LockOpen"
+                                         ToggledIcon="@Icons.Material.Filled.Lock" />
+                </MudTooltip>
+            }
             @ExtraButtons
         </MudButtonGroup>
     }
@@ -73,6 +73,20 @@
         {
             <MudProgressCircular Color="Color.Default" Indeterminate="true" Class="mt-8 mb-8" />
         }        
+    }
+    else
+    {
+        <MudButtonGroup Color="Color.Primary" Variant="Variant.Text" Size="Size.Small" Class="mt-2">
+            @if (Lockable)
+            {
+                <MudTooltip Text="Lock slot for Auto Builder">
+                    <MudToggleIconButton @bind-Toggled="@Locked" Color="Color.Dark" ToggledColor="Color.Primary"
+                                         Icon="@Icons.Material.Filled.LockOpen"
+                                         ToggledIcon="@Icons.Material.Filled.Lock" />
+                </MudTooltip>
+            }
+            @ExtraButtons
+        </MudButtonGroup>
     }
 </MudPaper>
 

--- a/PokeAutobuilder/Shared/PokemonSearchBox.razor
+++ b/PokeAutobuilder/Shared/PokemonSearchBox.razor
@@ -30,12 +30,12 @@
 
     @if (Pokemon is not null)
     {
-        <div style="height: 50px">
+        <div style="height: 50px; margin-top: 5px;">
             @if (_pokemonSearchValueVarieties.Count > 1
                     && !_locked)
             {
                 <MudSelect Dense="true" T="string" Label="Form" AnchorOrigin="Origin.BottomCenter" TransformOrigin="Origin.TopCenter"
-                           @bind-Value="_PokemonFormName">
+                           @bind-Value="_PokemonFormName" ToStringFunc="@((string formName) => StringUtils.PrettifyString(formName))" >
                     @foreach (var v in _pokemonSearchValueVarieties)
                     {
                         <MudSelectItem Value="@v.Name" />
@@ -257,7 +257,7 @@
         var parameters = new DialogParameters();
         parameters.Add("Pokemon", Pokemon);
 
-        var dialog = await DialogService.ShowAsync<PokemonDetailsDialog>(StringUtils.FirstCharToUpper(Pokemon!.Name), parameters);
+        var dialog = await DialogService.ShowAsync<PokemonDetailsDialog>(StringUtils.PrettifyString(Pokemon!.Name), parameters);
         var result = await dialog.Result;
 
         if (result is not null

--- a/PokeAutobuilder/Shared/PokemonStorageBox.razor
+++ b/PokeAutobuilder/Shared/PokemonStorageBox.razor
@@ -2,7 +2,7 @@
 @using PokeAutobuilder.Source.Services;
 @using PokemonDataModel
 
-<MudPaper Class="d-flex mud-width-full mud-height-full pa-2" Style="background: var(--mud-palette-background)" Outlined="true" Square="true">
+<MudPaper Class="d-flex mud-width-full mud-height-full pa-2" Style="background: var(--mud-palette-background); min-height: 300px;" Outlined="true" Square="true">
 	<div class="d-flex flex-wrap justify-start align-content-start py-1" style="overflow: auto;">
 		@foreach (SmartPokemon? p in PokemonCollection!)
 		{

--- a/PokeAutobuilder/Source/JsonValidator.cs
+++ b/PokeAutobuilder/Source/JsonValidator.cs
@@ -1,0 +1,35 @@
+﻿using PokemonDataModel;
+using System.Text.Json;
+
+namespace PokeAutobuilder.Source
+{
+    public static class JsonValidator
+    {
+        private static readonly JsonSerializerOptions deserializeOptions = new()
+        {
+            
+        };
+
+        public static bool TryValidatePokemonBoxJson(string json, out PokemonBox? box)
+        {
+            try
+            {
+                box = JsonSerializer.Deserialize<PokemonBox>(json, deserializeOptions);
+
+                if (box == null || box.Pokemon == null)
+                    return false;
+
+                // Optional: further validation logic, e.g. ensure no nulls in Pokemon list
+                if (box.Pokemon.Any(p => p == null))
+                    return false;
+
+                return true;
+            }
+            catch
+            {
+                box = null;
+                return false;
+            }
+        }
+    }
+}

--- a/PokeAutobuilder/Source/Services/ProfileService.cs
+++ b/PokeAutobuilder/Source/Services/ProfileService.cs
@@ -2,6 +2,7 @@
 using Blazored.LocalStorage;
 using Blazored.SessionStorage;
 using Microsoft.VisualBasic;
+using PokeApiNet;
 using PokemonDataModel;
 using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices;
@@ -95,7 +96,7 @@ namespace PokeAutobuilder.Source.Services
                     }
                     else if (_pokemonStorage.Boxes.Count == 0)
                     {
-                        _pokemonStorage.Boxes.Add(new PokemonBox("Pokémon Storage"));
+                        _pokemonStorage.Boxes.Add(new PokemonBox("Box 1"));
                     }
 
                     await SetPokemonStorageAsync(_pokemonStorage);
@@ -103,11 +104,7 @@ namespace PokeAutobuilder.Source.Services
                 }
                 else
                 {
-                    _pokemonStorage = await _localStorageService.GetItemAsync<PokemonStorage>(POKEMON_STORAGE_KEY) is { } pokemonStorage ? pokemonStorage : new();
-                    if (_pokemonStorage.Boxes.Count == 0)
-                    {
-                        _pokemonStorage.Boxes.Add(new PokemonBox("Pokémon Storage"));
-                    }
+                    await LoadPokemonStorageAsync();
                 }
 
                 // load team storage
@@ -174,6 +171,14 @@ namespace PokeAutobuilder.Source.Services
             await _localStorageService.SetItemAsync(POKEMON_TYPES_KEY, allTypes);
         }
 
+        public async Task LoadPokemonStorageAsync()
+        {
+            _pokemonStorage = await _localStorageService.GetItemAsync<PokemonStorage>(POKEMON_STORAGE_KEY) is { } pokemonStorage ? pokemonStorage : new();
+            if (_pokemonStorage.Boxes.Count == 0)
+            {
+                _pokemonStorage.Boxes.Add(new PokemonBox("Box 1"));
+            }
+        }
         public async Task SetPokemonStorageAsync(PokemonStorage storage)
         {
             OnStorageChange?.Invoke();
@@ -183,36 +188,46 @@ namespace PokeAutobuilder.Source.Services
         {
             await SetPokemonStorageAsync(PokemonStorage);
         }
-        public async Task AddPokemonToStorageAsync(SmartPokemon pokemon)
+        public async Task AddPokemonToStorageAsync(SmartPokemon pokemon, int boxIdx)
         {
-            if (PokemonStorage == null) return;
+            if (boxIdx < 0 || boxIdx >= PokemonStorage.Boxes.Count)
+            {
+                throw new IndexOutOfRangeException($"Box with index {boxIdx} does not exist in storage.");
+            }
 
-            PokemonStorage.Boxes[0].Pokemon.Add(pokemon);
-            await SetPokemonStorageAsync(PokemonStorage);
+            PokemonStorage.Boxes[boxIdx].Pokemon.Add(pokemon);
+            await UpdatePokemonStorageAsync();
         }
+        public PokemonBox? FindPokemonBoxForPokemon(SmartPokemon pokemon)
+        {
+            return PokemonStorage.Boxes.Where(box => box.Pokemon.Contains(pokemon)).FirstOrDefault();
+        }
+
         public async Task<bool> RemovePokemonFromStorageAsync(SmartPokemon pokemon)
         {
-            if (PokemonStorage == null) return false;
+            PokemonBox? owningBox = FindPokemonBoxForPokemon(pokemon);
+            if (owningBox is null) return false;
 
-            bool removed = PokemonStorage.Boxes[0].Pokemon.Remove(pokemon);
+            bool removed = owningBox.Pokemon.Remove(pokemon);
             if (removed)
-                await SetPokemonStorageAsync(PokemonStorage);
+                await UpdatePokemonStorageAsync();
 
             return removed;
         }
         public async Task<bool> ReplacePokemonInStorageAsync(SmartPokemon oldPokemon, SmartPokemon newPokemon)
         {
-            if (PokemonStorage == null) return false;
+            PokemonBox? owningBox = FindPokemonBoxForPokemon(oldPokemon);
+            if (owningBox is null) return false;
 
-            int pokemonIdx = PokemonStorage.Boxes[0].Pokemon.IndexOf(oldPokemon);
+            int pokemonIdx = owningBox.Pokemon.IndexOf(oldPokemon);
 
             if (pokemonIdx < 0)
                 return false;
 
-            PokemonStorage.Boxes[0].Pokemon.RemoveAt(pokemonIdx);
-            PokemonStorage.Boxes[0].Pokemon.Insert(pokemonIdx, newPokemon);
+            owningBox.Pokemon.RemoveAt(pokemonIdx);
+            owningBox.Pokemon.Insert(pokemonIdx, newPokemon);
 
-            await SetPokemonStorageAsync(PokemonStorage);
+            await UpdatePokemonStorageAsync();
             return true;
         }
 

--- a/PokeAutobuilder/wwwroot/index.html
+++ b/PokeAutobuilder/wwwroot/index.html
@@ -97,6 +97,7 @@
         }
 
     </script>
+    <script src="local-storage-helper.js"></script>
 </body>
 
 </html>

--- a/PokeAutobuilder/wwwroot/local-storage-helper.js
+++ b/PokeAutobuilder/wwwroot/local-storage-helper.js
@@ -64,23 +64,25 @@
                     throw new Error("Failed to import box. Pokemon storage has not been created yet.");
                 }
 
-                const box = JSON.parse(reader.result);
+                const boxJson = reader.result;
+                dotNetHelper.invokeMethodAsync("ValidateBoxJson", boxJson)
+                    .then(isValid => {
+                        if (!isValid) {
+                            console.error("Box JSON is invalid.");
+                            dotNetHelper.invokeMethodAsync("OnUploadBoxFailure", "Box JSON is invalid.");
+                            return;
+                        }
 
-                if (!("pokemon" in box)
-                    || !("name" in box)) {
-                    console.error("Failed to import box. The input data cannot be parsed.");
-                    throw new Error("Failed to import box. The input data cannot be parsed.");
-                }
-
-                // Todo: call function to validate the box before adding it to storage
-
-                pokemonStorage.boxes.push(box);
-
-                localStorage.setItem(storageKey, JSON.stringify(pokemonStorage));
-
-                dotNetHelper.invokeMethodAsync("OnUploadBoxSuccessAsync");
-            } catch {
-                dotNetHelper.invokeMethodAsync("OnUploadBoxFailure");
+                        const box = JSON.parse(boxJson);
+                        pokemonStorage.boxes.push(box);
+                        localStorage.setItem(storageKey, JSON.stringify(pokemonStorage));
+                        dotNetHelper.invokeMethodAsync("OnUploadBoxSuccessAsync");
+                    })
+                    .catch((e) => {
+                        dotNetHelper.invokeMethodAsync("OnUploadBoxFailure", e);
+                    });
+            } catch (e) {
+                dotNetHelper.invokeMethodAsync("OnUploadBoxFailure", e);
             }
         };
 

--- a/PokeAutobuilder/wwwroot/local-storage-helper.js
+++ b/PokeAutobuilder/wwwroot/local-storage-helper.js
@@ -78,9 +78,9 @@
 
                 localStorage.setItem(storageKey, JSON.stringify(pokemonStorage));
 
-                // dotNetHelper.invokeMethodAsync("OnImportSuccess");
+                dotNetHelper.invokeMethodAsync("OnUploadBoxSuccessAsync");
             } catch {
-                // dotNetHelper.invokeMethodAsync("OnImportFailure");
+                dotNetHelper.invokeMethodAsync("OnUploadBoxFailure");
             }
         };
 

--- a/PokeAutobuilder/wwwroot/local-storage-helper.js
+++ b/PokeAutobuilder/wwwroot/local-storage-helper.js
@@ -1,0 +1,89 @@
+﻿window.localStorageHelper = {
+    exportBoxToFile: function (storageKey, boxIdx, filename) {
+        var box = null;
+        for (let i = 0; i < localStorage.length; i++) {
+            const key = localStorage.key(i);
+            if (key.startsWith(storageKey)) {
+                const pokemonStorageJson = localStorage.getItem(key);
+
+                try {
+                    const data = JSON.parse(pokemonStorageJson);
+                    if (Array.isArray(data.boxes) && boxIdx >= 0 && boxIdx < data.boxes.length) {
+                        box = data.boxes[boxIdx];
+                    }
+                } catch (e) {
+                    console.error("Failed to parse JSON", e);
+                }
+            }
+        }
+
+        if (box == null) {
+            console.error("Failed to export box.");
+            return;
+        }
+
+        const blob = new Blob([JSON.stringify(box, null, 2)], { type: "application/json" });
+        const url = URL.createObjectURL(blob);
+
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = filename;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+    },
+
+    importBoxFromFile: function (storageKey, fileInputId, dotNetHelper) {
+        const input = document.getElementById(fileInputId);
+        if (!input || !input.files.length) {
+            return;
+        }
+
+        const file = input.files[0];
+        const reader = new FileReader();
+
+        reader.onload = () => {
+            try {
+                var pokemonStorage = null;
+                for (let i = 0; i < localStorage.length; i++) {
+                    const key = localStorage.key(i);
+                    if (key.startsWith(storageKey)) {
+                        const pokemonStorageJson = localStorage.getItem(key);
+
+                        try {
+                            pokemonStorage = JSON.parse(pokemonStorageJson);
+                        } catch (e) {
+                            console.error("Failed to parse the pokemon storage for input.", e);
+                        }
+                    }
+                }
+
+                if (pokemonStorage == null || !Array.isArray(pokemonStorage.boxes)) {
+                    console.error("Failed to import box. Pokemon storage has not been created yet.");
+                    throw new Error("Failed to import box. Pokemon storage has not been created yet.");
+                }
+
+                const box = JSON.parse(reader.result);
+
+                if (!("pokemon" in box)
+                    || !("name" in box)) {
+                    console.error("Failed to import box. The input data cannot be parsed.");
+                    throw new Error("Failed to import box. The input data cannot be parsed.");
+                }
+
+                // Todo: call function to validate the box before adding it to storage
+
+                pokemonStorage.boxes.push(box);
+
+                localStorage.setItem(storageKey, JSON.stringify(pokemonStorage));
+
+                // dotNetHelper.invokeMethodAsync("OnImportSuccess");
+            } catch {
+                // dotNetHelper.invokeMethodAsync("OnImportFailure");
+            }
+        };
+
+        reader.readAsText(file);
+    }
+};

--- a/PokemonDataModel/ILazyPokemonList.cs
+++ b/PokemonDataModel/ILazyPokemonList.cs
@@ -14,5 +14,6 @@ namespace PokemonDataModel
             set;
         }
         Task<IEnumerable<IPokemonSearchable>> GetListAsync();
+        bool IsEmpty();
     }
 }

--- a/PokemonDataModel/Pokedex.cs
+++ b/PokemonDataModel/Pokedex.cs
@@ -166,5 +166,11 @@ namespace PokemonDataModel
 
             return this;
         }
+
+        // assume a pokedex is never empty
+        public bool IsEmpty()
+        {
+            return false;
+        }
     }
 }

--- a/PokemonDataModel/Pokedex.cs
+++ b/PokemonDataModel/Pokedex.cs
@@ -40,7 +40,7 @@ namespace PokemonDataModel
 
         public override string ToString()
         {
-            return StringUtils.FirstCharToUpper(SpeciesResource.Name);
+            return StringUtils.PrettifyString(SpeciesResource.Name);
         }
 
         IEnumerable<NamedApiResource<Pokemon>> IPokemonSearchable.GetAllVarieties()

--- a/PokemonDataModel/Pokemon.cs
+++ b/PokemonDataModel/Pokemon.cs
@@ -643,7 +643,7 @@ namespace PokemonDataModel
 
         public override string ToString()
         {
-            return StringUtils.FirstCharToUpper(Name);
+            return StringUtils.PrettifyString(Name);
         }
 
         public IEnumerable<NamedApiResource<Pokemon>> GetAllVarieties()

--- a/PokemonDataModel/PokemonStorage.cs
+++ b/PokemonDataModel/PokemonStorage.cs
@@ -97,6 +97,11 @@ namespace PokemonDataModel
         {
             return Task.Run(() => Pokemon.AsEnumerable<IPokemonSearchable>());
         }
+
+        public bool IsEmpty()
+        {
+            return Pokemon.Count == 0;
+        }
     }
 
     public class PokemonStorage

--- a/PokemonDataModel/PokemonTeam.cs
+++ b/PokemonDataModel/PokemonTeam.cs
@@ -24,7 +24,7 @@ namespace PokemonDataModel
                     {
                         if (p is not null)
                         {
-                            defaultName += StringUtils.FirstCharToUpper(p.Name) + ", ";
+                            defaultName += StringUtils.PrettifyString(p.Name) + ", ";
                         }
                     }
 

--- a/Utility/Utility.cs
+++ b/Utility/Utility.cs
@@ -2,7 +2,18 @@
 {
     public class StringUtils
     {
-        public static string FirstCharToUpper(string input)
+        public static string PrettifyString(string input)
+        {
+            if (string.IsNullOrWhiteSpace(input))
+                return input;
+
+            return string.Join(" ", input
+                .Split('-')
+                .Where(word => !string.IsNullOrWhiteSpace(word))
+                .Select(word => char.ToUpper(word[0]) + word.Substring(1)));
+        }
+
+        public static string FirstCharToUpper2(string input)
         {
             if (string.IsNullOrEmpty(input))
                 throw new ArgumentException("ARGH!");


### PR DESCRIPTION
- Completely revamped the storage page controls with a new toolbar.
  - Add/remove boxes. You can now have more than one box in storage!
  - Box pagination controls for selecting the various storage boxes.
  - Box name control. Boxes can be named to identify them.
  - Import/export box controls. Box data can be exported to a .json file and imported anywhere so now you can move between machines or backup your data!
 
- Base stat charts have been revamped. The data should be much easier to digest now.

- The Auto Builder will now select Pokémon from the currently selected box.
  - The box can be selected by changing the search location on the Team Builder page.
  - The currently selected box is also displayed under the Auto Builder button.